### PR TITLE
Add an ignored list of tests for features unsupported by Scylla

### DIFF
--- a/logsubprocess.py
+++ b/logsubprocess.py
@@ -2,21 +2,24 @@ import subprocess
 import os
 import logging
 
+
 def dryRun():
-    return os.getenv( 'DRY_RUN' ) == 'true'
+    return os.getenv('DRY_RUN') == 'true'
 
-def wrap( attributeName ):
-    original = getattr( subprocess, attributeName )
-    def _wrappedInLogging( * args, ** kwargs ):
-        if type( args[ 0 ] ) is list:
-            commandString = ' '.join( args[ 0 ] )
+
+def wrap(attributeName):
+    original = getattr(subprocess, attributeName)
+
+    def _wrappedInLogging(* args, ** kwargs):
+        if type(args[0]) is list:
+            commandString = ' '.join(args[0])
         else:
-            commandString = args[ 0 ]
-        logging.info( '{}: {}'.format( attributeName, commandString ) )
+            commandString = args[0]
+        logging.info('{}: {}'.format(attributeName, commandString))
         if dryRun():
-            return original( [ 'true' ] )
-        return original( * args, ** kwargs )
+            return original(['true'])
+        return original(* args, ** kwargs)
 
-    setattr( subprocess, attributeName, _wrappedInLogging )
+    setattr(subprocess, attributeName, _wrappedInLogging)
 
-wrap( 'Popen' )
+wrap('Popen')

--- a/main.py
+++ b/main.py
@@ -1,32 +1,33 @@
 import logsubprocess
 import logging
-logging.basicConfig( level = logging.INFO )
+logging.basicConfig(level=logging.INFO)
 import run
 import os
 import argparse
 
-def main( pythonDriverGit, scyllaInstallDirectory, tests ):
+
+def main(pythonDriverGit, scyllaInstallDirectory, tests):
     versions = '3.0.0', '3.2.0', '3.4.0', '3.5.0'
     results = []
     for version in versions:
-        results.append( run.Run( pythonDriverGit, scyllaInstallDirectory, version, tests ) )
+        results.append(run.Run(pythonDriverGit, scyllaInstallDirectory, version, tests))
 
-    print( '=== PYTHON DRIVER MATRIX RESULTS ===' )
+    print('=== PYTHON DRIVER MATRIX RESULTS ===')
     failed = False
     for result in results:
-        print( result )
-        if result.summary[ 'failure' ] > 0:
+        print(result)
+        if result.summary['failure'] > 0:
             failed = True
 
     if failed:
-        quit( 1 )
+        quit(1)
     else:
-        quit( 0 )
+        quit(0)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument( 'pythonDriverGit', help = 'folder with git repository of python-driver' )
-    parser.add_argument( 'scyllaInstallDirectory', help = 'folder with scylla installation, e.g. a checked out git scylla has been built' )
-    parser.add_argument( '--tests', default = 'tests.integration.standard', help = 'tests to pass to nosetests tool, default=tests.integration.standard' )
+    parser.add_argument('pythonDriverGit', help='folder with git repository of python-driver')
+    parser.add_argument('scyllaInstallDirectory', help='folder with scylla installation, e.g. a checked out git scylla has been built')
+    parser.add_argument('--tests', default='tests.integration.standard', help='tests to pass to nosetests tool, default=tests.integration.standard')
     arguments = parser.parse_args()
-    main( arguments.pythonDriverGit, arguments.scyllaInstallDirectory, arguments.tests )
+    main(arguments.pythonDriverGit, arguments.scyllaInstallDirectory, arguments.tests)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
-import logsubprocess
 import logging
 logging.basicConfig(level=logging.INFO)
-import run
-import os
 import argparse
+
+import run
 
 
 def main(pythonDriverGit, scyllaInstallDirectory, tests):

--- a/processjunit.py
+++ b/processjunit.py
@@ -3,31 +3,33 @@ import logging
 import yaml
 import os
 
+
 class ProcessJUnit:
-    def __init__( self, xunitFile, ignoreFile ):
-        tree = xml.etree.ElementTree.parse( xunitFile )
-        self._ignore = self._ignoreSet( ignoreFile )
-        logging.info( 'ignoring {}'.format( self._ignore ) )
-        self._summary = { 'testcase': 0, 'failure': 0, 'skipped': 0, 'ignored_in_analysis': 0 }
+
+    def __init__(self, xunitFile, ignoreFile):
+        tree = xml.etree.ElementTree.parse(xunitFile)
+        self._ignore = self._ignoreSet(ignoreFile)
+        logging.info('ignoring {}'.format(self._ignore))
+        self._summary = {'testcase': 0, 'failure': 0, 'skipped': 0, 'ignored_in_analysis': 0}
         for element in tree.getiterator():
-            if self._shouldIgnore( element ):
-                self._summary[ 'ignored_in_analysis' ] += 1
+            if self._shouldIgnore(element):
+                self._summary['ignored_in_analysis'] += 1
                 continue
             if element.tag in self._summary:
-                self._summary[ element.tag ] += 1
+                self._summary[element.tag] += 1
 
-    def _ignoreSet( self, file ):
-        logging.info( 'looking for ignore.yaml file {}'.format( file ) )
-        if not os.path.exists( file ):
+    def _ignoreSet(self, file):
+        logging.info('looking for ignore.yaml file {}'.format(file))
+        if not os.path.exists(file):
             return set()
-        with open( file ) as f:
-            content = yaml.load( f )
-            return set( content[ 'tests' ] )
+        with open(file) as f:
+            content = yaml.load(f)
+            return set(content['tests'])
 
-    def _shouldIgnore( self, element ):
-        fullName = '{}.{}'.format( element.get( 'classname' ), element.get( 'name' ) )
+    def _shouldIgnore(self, element):
+        fullName = '{}.{}'.format(element.get('classname'), element.get('name'))
         return fullName in self._ignore
 
     @property
-    def summary( self ):
+    def summary(self):
         return self._summary

--- a/processjunit.py
+++ b/processjunit.py
@@ -1,7 +1,8 @@
-import xml.etree.ElementTree
 import logging
-import yaml
 import os
+import xml.etree.ElementTree
+
+import yaml
 
 
 class ProcessJUnit:

--- a/run.py
+++ b/run.py
@@ -3,55 +3,57 @@ import processjunit
 import shutil
 import os
 
+
 class Run:
-    def __init__( self, pythonDriverDirectory, scyllaInstallDirectory, tag, tests ):
+
+    def __init__(self, pythonDriverDirectory, scyllaInstallDirectory, tag, tests):
         self._tag = tag
         self._scyllaInstallDirectory = scyllaInstallDirectory
-        os.chdir( pythonDriverDirectory )
-        subprocess.check_call( 'git checkout .'.format( tag ), shell = True )
-        subprocess.check_call( 'git checkout {}'.format( tag ), shell = True )
+        os.chdir(pythonDriverDirectory)
+        subprocess.check_call('git checkout .'.format(tag), shell=True)
+        subprocess.check_call('git checkout {}'.format(tag), shell=True)
         self._setupOutputDirectory()
         self._applyPatch()
-        testCommand = 'nosetests --with-xunit --xunit-file {} -s {}'.format( self._xunitFile(), tests )
-        subprocess.call( testCommand.split(), env = self._environment() )
-        self._junit = processjunit.ProcessJUnit( self._xunitFile(), self._ignoreFile() )
-        content = open( self._xunitFile() ).read()
-        open( self._xunitFile(), 'w' ).write( content.replace( 'classname="', 'classname="version_{}_'.format(tag) ) )
+        testCommand = 'nosetests --with-xunit --xunit-file {} -s {}'.format(self._xunitFile(), tests)
+        subprocess.call(testCommand.split(), env=self._environment())
+        self._junit = processjunit.ProcessJUnit(self._xunitFile(), self._ignoreFile())
+        content = open(self._xunitFile()).read()
+        open(self._xunitFile(), 'w').write(content.replace('classname="', 'classname="version_{}_'.format(tag)))
 
     @property
-    def summary( self ):
+    def summary(self):
         return self._junit.summary
 
-    def __repr__( self ):
-        details = dict( version = self._tag )
-        details.update( self._junit.summary )
-        return '{version}: pass: {testcase}, failure: {failure}, skipped: {skipped}, ignored_in_analysis: {ignored_in_analysis}'.format( ** details )
+    def __repr__(self):
+        details = dict(version=self._tag)
+        details.update(self._junit.summary)
+        return '{version}: pass: {testcase}, failure: {failure}, skipped: {skipped}, ignored_in_analysis: {ignored_in_analysis}'.format(** details)
 
-    def _setupOutputDirectory( self ):
-        self._xunitDirectory = os.path.join( 'xunit', self._tag )
+    def _setupOutputDirectory(self):
+        self._xunitDirectory = os.path.join('xunit', self._tag)
         try:
-            shutil.rmtree( self._xunitDirectory )
+            shutil.rmtree(self._xunitDirectory)
         except:
             pass
-        os.makedirs( self._xunitDirectory )
+        os.makedirs(self._xunitDirectory)
 
-    def _xunitFile( self ):
-        return os.path.join( self._xunitDirectory, 'nosetests.{}.xml'.format( self._tag ) )
+    def _xunitFile(self):
+        return os.path.join(self._xunitDirectory, 'nosetests.{}.xml'.format(self._tag))
 
-    def _ignoreFile( self ):
-        here = os.path.dirname( __file__ )
-        ignoreFile = os.path.join( here, 'versions', self._tag, 'ignore.yaml' )
+    def _ignoreFile(self):
+        here = os.path.dirname(__file__)
+        ignoreFile = os.path.join(here, 'versions', self._tag, 'ignore.yaml')
         return ignoreFile
 
-    def _environment( self ):
+    def _environment(self):
         result = {}
-        result.update( os.environ )
-        result[ 'PROTOCOL_VERSION' ] = '3'
-        result[ 'INSTALL_DIRECTORY' ] = self._scyllaInstallDirectory
+        result.update(os.environ)
+        result['PROTOCOL_VERSION'] = '3'
+        result['INSTALL_DIRECTORY'] = self._scyllaInstallDirectory
         return result
 
-    def _applyPatch( self ):
-        here = os.path.dirname( __file__ )
-        patchFile = os.path.join( here, 'versions', self._tag, 'patch' )
-        command = "patch -p1 -i {}".format( patchFile )
-        subprocess.check_call( command, shell = True )
+    def _applyPatch(self):
+        here = os.path.dirname(__file__)
+        patchFile = os.path.join(here, 'versions', self._tag, 'patch')
+        command = "patch -p1 -i {}".format(patchFile)
+        subprocess.check_call(command, shell=True)

--- a/run.py
+++ b/run.py
@@ -1,7 +1,8 @@
-import subprocess
-import processjunit
-import shutil
 import os
+import shutil
+import subprocess
+
+import processjunit
 
 
 class Run:

--- a/run.py
+++ b/run.py
@@ -18,10 +18,10 @@ class Run:
         subprocess.check_call('git checkout {}'.format(tag), shell=True)
         self._setupOutputDirectory()
         self._applyPatch()
-        exclude_str = ''
+        exclude_str = ' '
         for ignore_element in self._ignoreSet():
             ignore_element = ignore_element.split('.')[-1]
-            exclude_str += '--exclude %s' % ignore_element
+            exclude_str += '--exclude %s ' % ignore_element
         testCommand = 'nosetests --with-xunit --xunit-file {} -s {} {}'.format(self._xunitFile(), tests, exclude_str)
         logging.info(testCommand)
         subprocess.call(testCommand.split(), env=self._environment())

--- a/versions/3.0.0/ignore.yaml
+++ b/versions/3.0.0/ignore.yaml
@@ -7,4 +7,6 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_batch_statements
     - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.0.0/ignore.yaml
+++ b/versions/3.0.0/ignore.yaml
@@ -7,4 +7,4 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
-    - tests.integration.standard.test_query.SerialConsistencyTests.*
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.0.0/ignore.yaml
+++ b/versions/3.0.0/ignore.yaml
@@ -1,0 +1,10 @@
+tests:
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_index
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_follows_alter
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_updates
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.*

--- a/versions/3.2.0/ignore.yaml
+++ b/versions/3.2.0/ignore.yaml
@@ -7,4 +7,6 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_batch_statements
     - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.2.0/ignore.yaml
+++ b/versions/3.2.0/ignore.yaml
@@ -7,4 +7,4 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
-    - tests.integration.standard.test_query.SerialConsistencyTests.*
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.2.0/ignore.yaml
+++ b/versions/3.2.0/ignore.yaml
@@ -1,0 +1,10 @@
+tests:
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_index
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_follows_alter
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_updates
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.*

--- a/versions/3.4.0/ignore.yaml
+++ b/versions/3.4.0/ignore.yaml
@@ -7,4 +7,6 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_batch_statements
     - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.4.0/ignore.yaml
+++ b/versions/3.4.0/ignore.yaml
@@ -7,4 +7,4 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
-    - tests.integration.standard.test_query.SerialConsistencyTests.*
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.4.0/ignore.yaml
+++ b/versions/3.4.0/ignore.yaml
@@ -1,0 +1,10 @@
+tests:
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_index
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_follows_alter
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_updates
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.*

--- a/versions/3.5.0/ignore.yaml
+++ b/versions/3.5.0/ignore.yaml
@@ -7,4 +7,6 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_batch_statements
     - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.5.0/ignore.yaml
+++ b/versions/3.5.0/ignore.yaml
@@ -7,4 +7,4 @@ tests:
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
     - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
-    - tests.integration.standard.test_query.SerialConsistencyTests.*
+    - tests.integration.standard.test_query.SerialConsistencyTests.test_conditional_update_with_prepared_statements

--- a/versions/3.5.0/ignore.yaml
+++ b/versions/3.5.0/ignore.yaml
@@ -1,0 +1,10 @@
+tests:
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_index
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_follows_alter
+    - tests.integration.standard.test_metadata.IndexMapTests.test_index_updates
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_legacy_tables
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_no_connection_refused_on_timeout
+    - tests.integration.standard.test_query.SerialConsistencyTests.*


### PR DESCRIPTION
Remove tests that require features unsupported by scylla -
secondary indexes and lightweight transactions.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>