### PR TITLE
fix(datastax patch): Make it work on the master

### DIFF
--- a/versions/datastax/3.23.0/ignore.yaml
+++ b/versions/datastax/3.23.0/ignore.yaml
@@ -1,0 +1,5 @@
+# Last verified state on Dec 21, 2018 by Roy Dahan
+tests:
+
+v4_tests:
+

--- a/versions/datastax/3.23.0/patch
+++ b/versions/datastax/3.23.0/patch
@@ -79,10 +79,10 @@ index d6f26acb..fb2b31ed 100644
 
      try:
          jvm_args = []
-@@ -580,7 +594,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
-         if 'graph' in workloads:
-             jvm_args += ['-Xms1500M', '-Xmx1500M']
-         else:
+@@ -575,7 +589,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+         # This will enable the Mirroring query handler which will echo our custom payload k,v pairs back
+ 
+         if 'graph' not in workloads:
 -            if PROTOCOL_VERSION >= 4:
 +            if PROTOCOL_VERSION >= 4 and not SCYLLA_VERSION:
                  jvm_args = [" -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"]

--- a/versions/scylla/3.23.0/ignore.yaml
+++ b/versions/scylla/3.23.0/ignore.yaml
@@ -1,0 +1,5 @@
+# Last verified state on Dec 21, 2018 by Roy Dahan
+tests:
+
+v4_tests:
+

--- a/versions/scylla/3.23.0/patch
+++ b/versions/scylla/3.23.0/patch
@@ -79,10 +79,10 @@ index d6f26acb..fb2b31ed 100644
 
      try:
          jvm_args = []
-@@ -580,7 +594,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
-         if 'graph' in workloads:
-             jvm_args += ['-Xms1500M', '-Xmx1500M']
-         else:
+@@ -575,7 +589,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+         # This will enable the Mirroring query handler which will echo our custom payload k,v pairs back
+ 
+         if 'graph' not in workloads:
 -            if PROTOCOL_VERSION >= 4:
 +            if PROTOCOL_VERSION >= 4 and not SCYLLA_VERSION:
                  jvm_args = [" -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"]


### PR DESCRIPTION
Master and 3.23.0 does not work due to the using unsupported 'use_single_interface' option for ccm populate routine.
