### PR TITLE
fix(ignore set): use safe_load instead of load

### DIFF
--- a/run.py
+++ b/run.py
@@ -93,7 +93,7 @@ class Run:
             logging.info('Cannot find ignore file for version {}'.format(self._tag))
             return set()
         with open(ignore_file_path) as f:
-            content = yaml.load(f)
+            content = yaml.safe_load(f)
             if 'tests' in content and content['tests']:
                 ignore_tests.extend(content['tests'])
             else:


### PR DESCRIPTION
Failed test: https://jenkins.scylladb.com/view/master/job/scylla-master/job/driver-tests/job/
python-driver-matrix-test/810/console

Error: TypeError: load() missing 1 required positional argument: 'Loader'

In pyyaml 6.0 the yaml.load() function requires parameter loader=Loader. Instead of that for simple
YAML (str, int, lists), can use yaml.safe_load()