### PR TITLE
fix(scylla/3.24.0/ignore.yaml): Marking test_connect_no_auth_provider as flaky

### DIFF
--- a/versions/scylla/3.24.0/ignore.yaml
+++ b/versions/scylla/3.24.0/ignore.yaml
@@ -65,3 +65,4 @@ v4_tests:
     - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_basic
     - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_custom_payload
   flaky:
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider


### PR DESCRIPTION
For Scylla's python-driver version 3.24.0 and protocol 4 this is flaky
 (sometimes it fails)
```python
    def test_connect_no_auth_provider(self):
        cluster = TestCluster()
        cluster.connect()
        cluster.refresh_nodes()
        down_hosts = [host for host in cluster.metadata.all_hosts() if not host.is_up]
>       self.assertEqual(len(down_hosts), 1)
E       AssertionError: 0 != 1

tests/integration/standard/test_authentication_misconfiguration.py:46: AssertionError
```