### PR TITLE
fix(processjunit.py): Fixing "xpassed" logic for passed test

### DIFF
--- a/processjunit.py
+++ b/processjunit.py
@@ -56,8 +56,8 @@ class ProcessJUnit:
                     category_type += "s"
             else:
                 category_type = "passed"
-                if is_ignore_test and is_flaky_test:
-                    # The test passed, and it appears in the YAML file as a test that needs to skip - so need to
+                if is_ignore_test or is_flaky_test:
+                    # The test passed, and it appears in the YAML file as a test that needs to ignore - so need to
                     # remove it from the YAML file
                     category_type = "xpassed"
 
@@ -133,4 +133,4 @@ class ProcessJUnit:
     def is_failed(self) -> bool:
         return not (self.summary["tests"] and self.summary["tests"] ==
                     self.summary["passed"] + self.summary["skipped"] + self.summary["ignored_in_analysis"] +
-                    self.summary["flaky"])
+                    self.summary["flaky"] + self.summary["xpassed"])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -106,13 +106,13 @@ class TestReportMechanism:
             f"{TEST_FILE_NAME}.TestWithMark.test_fail_but_marked_as_expected_failure"}
 
     def test_passed(self, report):
-        pass_flaky_test_name = f"{TEST_FILE_NAME}.TestWithMark.test_flaky_pass"
-        assert pass_flaky_test_name in IGNORE_SET["flaky"]
-        assert report.summary_full_details["passed"] == \
-               {f"{TEST_FILE_NAME}.TestWithMark.test_pass", pass_flaky_test_name}
+        assert report.summary_full_details["passed"] == {f"{TEST_FILE_NAME}.TestWithMark.test_pass"}
 
     def test_xpassed(self, report):
+        pass_flaky_test_name = f"{TEST_FILE_NAME}.TestWithMark.test_flaky_pass"
+        assert pass_flaky_test_name in IGNORE_SET["flaky"]
         assert report.summary_full_details["xpassed"] == {
+            pass_flaky_test_name,
             f"{TEST_FILE_NAME}.TestWithMark.test_pass_but_marked_as_expected_failure"}
 
     def test_skipped(self, report):
@@ -125,3 +125,6 @@ class TestReportMechanism:
 
     def test_save_new_report_after_analysis(self, report):
         report.save_after_analysis(driver_version="3.25.0", protocol=3, python_driver_type="scylla")
+
+    def test_is_report_failed(self, report):
+        assert report.is_failed


### PR DESCRIPTION
* Passed test will mark as `xpassed` if it marks as "ignore" or "flaky" 
test.
* test_is_report_failed - Adding a new test to verify "is_failed" property
 returns True if the report contains errors or failures.