### PR TITLE
fix test_connection_honor_cluster_port setup_module

### DIFF
--- a/versions/datastax/3.24.0/patch.patch
+++ b/versions/datastax/3.24.0/patch.patch
@@ -131,6 +131,19 @@ index 546141d8..a8cb9396 100644
      @classmethod
      def setUpClass(cls):
          if not USE_CASS_EXTERNAL:
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
 diff --git c/tests/integration/standard/test_metadata.py w/tests/integration/standard/test_metadata.py
 index bd556f35..c1e9760b 100644
 --- c/tests/integration/standard/test_metadata.py

--- a/versions/datastax/3.25.0/patch.patch
+++ b/versions/datastax/3.25.0/patch.patch
@@ -131,6 +131,19 @@ index 546141d8..a8cb9396 100644
      @classmethod
      def setUpClass(cls):
          if not USE_CASS_EXTERNAL:
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
 diff --git c/tests/integration/standard/test_metadata.py w/tests/integration/standard/test_metadata.py
 index bd556f35..c1e9760b 100644
 --- c/tests/integration/standard/test_metadata.py

--- a/versions/scylla/3.24.0/patch.patch
+++ b/versions/scylla/3.24.0/patch.patch
@@ -50,6 +50,19 @@ index fb551c00..9fa6c7a4 100644
      def test_deprecation_warning_default_consistency_level(self):
          """
          Tests the deprecation warning has been added when enabling
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
 diff --git c/tests/integration/standard/test_custom_payload.py w/tests/integration/standard/test_custom_payload.py
 index 51383de9..b00687e8 100644
 --- c/tests/integration/standard/test_custom_payload.py

--- a/versions/scylla/3.25.0/patch.patch
+++ b/versions/scylla/3.25.0/patch.patch
@@ -50,6 +50,19 @@ index 8bdae65c..21009614 100644
      def test_deprecation_warning_default_consistency_level(self):
          """
          Tests the deprecation warning has been added when enabling
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
 diff --git c/tests/integration/standard/test_custom_payload.py w/tests/integration/standard/test_custom_payload.py
 index 51383de9..b00687e8 100644
 --- c/tests/integration/standard/test_custom_payload.py

--- a/versions/scylla/3.25.2/patch.patch
+++ b/versions/scylla/3.25.2/patch.patch
@@ -42,6 +42,19 @@ index f69ab6f5..b37fba5e 100644
      def test_compact_option(self):
          """
          Test the driver can connect with the no_compact option and the results
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
 diff --git c/tests/integration/standard/test_custom_payload.py w/tests/integration/standard/test_custom_payload.py
 index 51383de9..b00687e8 100644
 --- c/tests/integration/standard/test_custom_payload.py


### PR DESCRIPTION
it wasn't waiting correctly for cluster to be up and
ready, and it was failing this test, and the next module
that was using the default test cluster