### PR TITLE
Fix patch for datastax 3.26.0

### DIFF
--- a/versions/datastax/3.26.0/ignore.yaml
+++ b/versions/datastax/3.26.0/ignore.yaml
@@ -1,0 +1,62 @@
+# Last verified state on Dec 21, 2018 by Roy Dahan
+tests:
+  ignore:
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_prepared_statements.PreparedStatementTests.test_imprecise_bind_values_dicts
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+    - tests.integration.standard.test_cluster.ClusterTests.test_replicas_are_queried
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider
+v4_tests:
+  ignore:
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_custom_payload
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_prepared
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_cql_called_on_null
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_schema_metadata
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_basic
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_after_udt
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_basic
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_aggregate_metadata
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_same_name_diff_types
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace_and_custom_payload
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_no_parameters
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_function_metadata
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_batching
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_after_functions
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_init_cond
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_cql_optional_params
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_same_name_diff_types
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_return_type_meta
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider

--- a/versions/datastax/3.26.0/patch.patch
+++ b/versions/datastax/3.26.0/patch.patch
@@ -1,0 +1,172 @@
+diff --git c/test-requirements.txt w/test-requirements.txt
+index 9e62bfde..a6b477a4 100644
+--- c/test-requirements.txt
++++ w/test-requirements.txt
+@@ -2,7 +2,7 @@
+ scales
+ nose
+ mock>1.1
+-ccm>=2.1.2
++#ccm>=2.1.2
+ pytz
+ sure
+ pure-sasl
+diff --git c/tests/integration/__init__.py w/tests/integration/__init__.py
+index 9d350af7..5d80827a 100644
+--- c/tests/integration/__init__.py
++++ w/tests/integration/__init__.py
+@@ -36,6 +36,7 @@ from itertools import groupby
+ import six
+ import shutil
+ 
++
+ from cassandra import OperationTimedOut, ReadTimeout, ReadFailure, WriteTimeout, WriteFailure, AlreadyExists,\
+     InvalidRequest
+ from cassandra.protocol import ConfigurationException
+@@ -44,6 +45,7 @@ from cassandra import ProtocolVersion
+ try:
+     from ccmlib.dse_cluster import DseCluster
+     from ccmlib.cluster import Cluster as CCMCluster
++    from ccmlib.scylla_cluster import ScyllaCluster as CCMScyllaCluster
+     from ccmlib.cluster_factory import ClusterFactory as CCMClusterFactory
+     from ccmlib import common
+ except ImportError as e:
+@@ -161,16 +163,21 @@ KEEP_TEST_CLUSTER = bool(os.getenv('KEEP_TEST_CLUSTER', False))
+ SIMULACRON_JAR = os.getenv('SIMULACRON_JAR', None)
+ CLOUD_PROXY_PATH = os.getenv('CLOUD_PROXY_PATH', None)
+ 
+-# Supported Clusters: Cassandra, DDAC, DSE
++# Supported Clusters: Cassandra, DDAC, DSE, Scylla
+ DSE_VERSION = None
++SCYLLA_VERSION = os.getenv('SCYLLA_VERSION', None)
+ if os.getenv('DSE_VERSION', None):  # we are testing against DSE
+     DSE_VERSION = Version(os.getenv('DSE_VERSION', None))
+     DSE_CRED = os.getenv('DSE_CREDS', None)
+     CASSANDRA_VERSION = _get_cass_version_from_dse(DSE_VERSION.base_version)
+     CCM_VERSION = DSE_VERSION.base_version
+ else:  # we are testing against Cassandra or DDAC
+-    cv_string = os.getenv('CASSANDRA_VERSION', None)
+-    mcv_string = os.getenv('MAPPED_CASSANDRA_VERSION', None)
++    if SCYLLA_VERSION:
++        cv_string = SCYLLA_VERSION
++        mcv_string = os.getenv('MAPPED_SCYLLA_VERSION', None)
++    else:
++        cv_string = os.getenv('CASSANDRA_VERSION', None)
++        mcv_string = os.getenv('MAPPED_CASSANDRA_VERSION', None)
+     try:
+         cassandra_version = Version(cv_string)  # env var is set to test-dse for DDAC
+     except:
+@@ -194,6 +201,8 @@ if DSE_VERSION:
+ elif CASSANDRA_DIR:
+     log.info("Using Cassandra dir: %s", CASSANDRA_DIR)
+     CCM_KWARGS['install_dir'] = CASSANDRA_DIR
++elif SCYLLA_VERSION:
++    CCM_KWARGS['cassandra_version'] = SCYLLA_VERSION
+ else:
+     log.info('Using Cassandra version: %s', CCM_VERSION)
+     CCM_KWARGS['version'] = CCM_VERSION
+@@ -436,7 +445,7 @@ def is_current_cluster(cluster_name, node_counts, workloads):
+         if [len(list(nodes)) for dc, nodes in
+                 groupby(CCM_CLUSTER.nodelist(), lambda n: n.data_center)] == node_counts:
+             for node in CCM_CLUSTER.nodelist():
+-                if set(node.workloads) != set(workloads):
++                if set(getattr(node, 'workloads', [])) != set(workloads):
+                     print("node workloads don't match creating new cluster")
+                     return False
+             return True
+@@ -557,8 +566,12 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+ 
+                 CCM_CLUSTER.set_dse_configuration_options(dse_options)
+             else:
+-                CCM_CLUSTER = CCMCluster(path, cluster_name, **ccm_options)
+-                CCM_CLUSTER.set_configuration_options({'start_native_transport': True})
++                if SCYLLA_VERSION:
++                    CCM_CLUSTER = CCMScyllaCluster(path, cluster_name, **ccm_options)
++                    CCM_CLUSTER.set_configuration_options({'experimental': True})
++                else:
++                    CCM_CLUSTER = CCMCluster(path, cluster_name, **ccm_options)
++                    CCM_CLUSTER.set_configuration_options({'start_native_transport': True})
+                 if Version(cassandra_version) >= Version('2.2'):
+                     CCM_CLUSTER.set_configuration_options({'enable_user_defined_functions': True})
+                     if Version(cassandra_version) >= Version('3.0'):
+@@ -571,18 +584,18 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+                             })
+                 common.switch_cluster(path, cluster_name)
+                 CCM_CLUSTER.set_configuration_options(configuration_options)
+-                CCM_CLUSTER.populate(nodes, ipformat=ipformat, use_single_interface=use_single_interface)
++                CCM_CLUSTER.populate(nodes, ipformat=ipformat)
+ 
+     try:
+         jvm_args = []
+ 
+         # This will enable the Mirroring query handler which will echo our custom payload k,v pairs back
+ 
+-        if 'graph' in workloads:
+-            jvm_args += ['-Xms1500M', '-Xmx1500M']
+-        else:
+-            if PROTOCOL_VERSION >= 4:
+-                jvm_args = [" -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"]
++        # if 'graph' in workloads:
++        #     jvm_args += ['-Xms1500M', '-Xmx1500M']
++        # else:
++        #     if PROTOCOL_VERSION >= 4:
++        #         jvm_args = [" -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"]
+         if len(workloads) > 0:
+             for node in CCM_CLUSTER.nodes.values():
+                 node.set_workloads(workloads)
+diff --git c/tests/integration/standard/test_authentication_misconfiguration.py w/tests/integration/standard/test_authentication_misconfiguration.py
+index 546141d8..a8cb9396 100644
+--- c/tests/integration/standard/test_authentication_misconfiguration.py
++++ w/tests/integration/standard/test_authentication_misconfiguration.py
+@@ -19,6 +19,12 @@ from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
+ 
+ class MisconfiguredAuthenticationTests(unittest.TestCase):
+     """ One node (not the contact point) has password auth. The rest of the nodes have no auth """
++    # TODO: 	Fix ccm to apply following options to scylla.yaml
++    # 	node3.set_configuration_options(values={
++    # 	'authenticator': 'PasswordAuthenticator',
++    # 	'authorizer': 'CassandraAuthorizer',
++    # 	})
++    # To make it working for scylla
+     @classmethod
+     def setUpClass(cls):
+         if not USE_CASS_EXTERNAL:
+diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
+index 84e07370..0ab1b264 100644
+--- c/tests/integration/standard/test_custom_cluster.py
++++ w/tests/integration/standard/test_custom_cluster.py
+@@ -29,7 +29,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
+diff --git c/tests/integration/standard/test_metadata.py w/tests/integration/standard/test_metadata.py
+index bd556f35..c1e9760b 100644
+--- c/tests/integration/standard/test_metadata.py
++++ w/tests/integration/standard/test_metadata.py
+@@ -2082,7 +2082,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
+ 
+         @test_category metadata
+         """
+-        self.assertIn("SizeTieredCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
++        self.assertIn(self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"], ["SizeTieredCompactionStrategy", "IncrementalCompactionStrategy"])
+ 
+         self.session.execute("ALTER MATERIALIZED VIEW {0}.mv1 WITH compaction = {{ 'class' : 'LeveledCompactionStrategy' }}".format(self.keyspace_name))
+         self.assertIn("LeveledCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
+diff --git c/tests/integration/standard/test_prepared_statements.py w/tests/integration/standard/test_prepared_statements.py
+index 5c79f273..0173763d 100644
+--- c/tests/integration/standard/test_prepared_statements.py
++++ w/tests/integration/standard/test_prepared_statements.py
+@@ -168,7 +168,7 @@ class PreparedStatementTests(unittest.TestCase):
+     def _run_too_many_bind_values(self, session):
+         statement_to_prepare = """ INSERT INTO test3rf.test (v) VALUES  (?)"""
+          # logic needed work with changes in CASSANDRA-6237
+-        if self.cass_version[0] >= (3, 0, 0):
++        if self.cass_version[0] >= (2, 2, 8):
+             self.assertRaises(InvalidRequest, session.prepare, statement_to_prepare)
+         else:
+             prepared = session.prepare(statement_to_prepare)


### PR DESCRIPTION
Since unittest2 package was removed in 3.26.0, we
need to remove it's refernece from out patch to make it apply cleanly

Fix: #51