### PR TITLE
Fix breakages of in python matrix

### DIFF
--- a/run.py
+++ b/run.py
@@ -104,10 +104,16 @@ class Run:
                     logging.info("Show patch's statistics for file '%s'", file_path)
                     self._run_command_in_shell(f"git apply --stat {file_path}")
                     logging.info("Detect patch's errors for file '%s'", file_path)
-                    self._run_command_in_shell(f"git apply --check {file_path}")
+                    try:
+                        self._run_command_in_shell(f"git apply --check {file_path}")
+                    except AssertionError as exc:
+                        if 'tests/integration/conftest.py' in str(exc):
+                            self._run_command_in_shell(f"rm tests/integration/conftest.py")
+                        else:
+                            raise
                     logging.info("Applying patch file '%s'", file_path)
                     self._run_command_in_shell(f"patch -p1 -i {file_path}")
-                except Exception as exc:
+                except Exception:
                     logging.exception("Failed to apply patch '%s' to version '%s'",
                                       file_path, self.driver_version)
                     raise

--- a/versions/datastax/3.26.0/patch.patch
+++ b/versions/datastax/3.26.0/patch.patch
@@ -1,7 +1,7 @@
-diff --git c/test-requirements.txt w/test-requirements.txt
-index 9e62bfde..a6b477a4 100644
---- c/test-requirements.txt
-+++ w/test-requirements.txt
+diff --git a/test-requirements.txt b/test-requirements.txt
+index 996cf434..d51c4895 100644
+--- a/test-requirements.txt
++++ b/test-requirements.txt
 @@ -2,7 +2,7 @@
  scales
  nose
@@ -11,11 +11,11 @@ index 9e62bfde..a6b477a4 100644
  pytz
  sure
  pure-sasl
-diff --git c/tests/integration/__init__.py w/tests/integration/__init__.py
-index 9d350af7..5d80827a 100644
---- c/tests/integration/__init__.py
-+++ w/tests/integration/__init__.py
-@@ -36,6 +36,7 @@ from itertools import groupby
+diff --git a/tests/integration/__init__.py b/tests/integration/__init__.py
+index a344931a..55ff3941 100644
+--- a/tests/integration/__init__.py
++++ b/tests/integration/__init__.py
+@@ -33,6 +33,7 @@ from itertools import groupby
  import six
  import shutil
  
@@ -23,7 +23,7 @@ index 9d350af7..5d80827a 100644
  from cassandra import OperationTimedOut, ReadTimeout, ReadFailure, WriteTimeout, WriteFailure, AlreadyExists,\
      InvalidRequest
  from cassandra.protocol import ConfigurationException
-@@ -44,6 +45,7 @@ from cassandra import ProtocolVersion
+@@ -41,6 +42,7 @@ from cassandra import ProtocolVersion
  try:
      from ccmlib.dse_cluster import DseCluster
      from ccmlib.cluster import Cluster as CCMCluster
@@ -31,7 +31,7 @@ index 9d350af7..5d80827a 100644
      from ccmlib.cluster_factory import ClusterFactory as CCMClusterFactory
      from ccmlib import common
  except ImportError as e:
-@@ -161,16 +163,21 @@ KEEP_TEST_CLUSTER = bool(os.getenv('KEEP_TEST_CLUSTER', False))
+@@ -166,16 +168,21 @@ KEEP_TEST_CLUSTER = bool(os.getenv('KEEP_TEST_CLUSTER', False))
  SIMULACRON_JAR = os.getenv('SIMULACRON_JAR', None)
  CLOUD_PROXY_PATH = os.getenv('CLOUD_PROXY_PATH', None)
  
@@ -56,7 +56,7 @@ index 9d350af7..5d80827a 100644
      try:
          cassandra_version = Version(cv_string)  # env var is set to test-dse for DDAC
      except:
-@@ -194,6 +201,8 @@ if DSE_VERSION:
+@@ -199,6 +206,8 @@ if DSE_VERSION:
  elif CASSANDRA_DIR:
      log.info("Using Cassandra dir: %s", CASSANDRA_DIR)
      CCM_KWARGS['install_dir'] = CASSANDRA_DIR
@@ -65,7 +65,7 @@ index 9d350af7..5d80827a 100644
  else:
      log.info('Using Cassandra version: %s', CCM_VERSION)
      CCM_KWARGS['version'] = CCM_VERSION
-@@ -436,7 +445,7 @@ def is_current_cluster(cluster_name, node_counts, workloads):
+@@ -441,7 +450,7 @@ def is_current_cluster(cluster_name, node_counts, workloads):
          if [len(list(nodes)) for dc, nodes in
                  groupby(CCM_CLUSTER.nodelist(), lambda n: n.data_center)] == node_counts:
              for node in CCM_CLUSTER.nodelist():
@@ -74,7 +74,7 @@ index 9d350af7..5d80827a 100644
                      print("node workloads don't match creating new cluster")
                      return False
              return True
-@@ -557,8 +566,12 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+@@ -563,8 +572,12 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
  
                  CCM_CLUSTER.set_dse_configuration_options(dse_options)
              else:
@@ -89,7 +89,7 @@ index 9d350af7..5d80827a 100644
                  if Version(cassandra_version) >= Version('2.2'):
                      CCM_CLUSTER.set_configuration_options({'enable_user_defined_functions': True})
                      if Version(cassandra_version) >= Version('3.0'):
-@@ -571,18 +584,18 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+@@ -577,18 +590,18 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
                              })
                  common.switch_cluster(path, cluster_name)
                  CCM_CLUSTER.set_configuration_options(configuration_options)
@@ -114,10 +114,39 @@ index 9d350af7..5d80827a 100644
          if len(workloads) > 0:
              for node in CCM_CLUSTER.nodes.values():
                  node.set_workloads(workloads)
-diff --git c/tests/integration/standard/test_authentication_misconfiguration.py w/tests/integration/standard/test_authentication_misconfiguration.py
+diff --git a/tests/integration/conftest.py b/tests/integration/conftest.py
+new file mode 100644
+index 00000000..7a4ae174
+--- /dev/null
++++ b/tests/integration/conftest.py
+@@ -0,0 +1,23 @@
++import os
++import logging
++
++import pytest
++from ccmlib.cluster_factory import ClusterFactory as CCMClusterFactory
++
++from . import CLUSTER_NAME, SINGLE_NODE_CLUSTER_NAME, MULTIDC_CLUSTER_NAME
++from . import path as ccm_path
++
++
++@pytest.fixture(scope="session", autouse=True)
++def cleanup_clusters():
++
++    yield
++
++    if not os.environ.get('DISABLE_CLUSTER_CLEANUP'):
++        for cluster_name in [CLUSTER_NAME, SINGLE_NODE_CLUSTER_NAME, MULTIDC_CLUSTER_NAME]:
++            try:
++                cluster = CCMClusterFactory.load(ccm_path, cluster_name)
++                logging.debug("Using external CCM cluster {0}".format(cluster.name))
++                cluster.clear()
++            except FileNotFoundError:
++                pass
+diff --git a/tests/integration/standard/test_authentication_misconfiguration.py b/tests/integration/standard/test_authentication_misconfiguration.py
 index 546141d8..a8cb9396 100644
---- c/tests/integration/standard/test_authentication_misconfiguration.py
-+++ w/tests/integration/standard/test_authentication_misconfiguration.py
+--- a/tests/integration/standard/test_authentication_misconfiguration.py
++++ b/tests/integration/standard/test_authentication_misconfiguration.py
 @@ -19,6 +19,12 @@ from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
  
  class MisconfiguredAuthenticationTests(unittest.TestCase):
@@ -131,11 +160,11 @@ index 546141d8..a8cb9396 100644
      @classmethod
      def setUpClass(cls):
          if not USE_CASS_EXTERNAL:
-diff --git c/tests/integration/standard/test_custom_cluster.py w/tests/integration/standard/test_custom_cluster.py
-index 84e07370..0ab1b264 100644
---- c/tests/integration/standard/test_custom_cluster.py
-+++ w/tests/integration/standard/test_custom_cluster.py
-@@ -29,7 +29,7 @@ def setup_module():
+diff --git a/tests/integration/standard/test_custom_cluster.py b/tests/integration/standard/test_custom_cluster.py
+index d0f10d51..d8353ec3 100644
+--- a/tests/integration/standard/test_custom_cluster.py
++++ b/tests/integration/standard/test_custom_cluster.py
+@@ -26,7 +26,7 @@ def setup_module():
      config_options = {'native_transport_port': 9046}
      ccm_cluster.set_configuration_options(config_options)
      # can't use wait_for_binary_proto cause ccm tries on port 9042
@@ -144,11 +173,11 @@ index 84e07370..0ab1b264 100644
      # wait until all nodes are up
      wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
      wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
-diff --git c/tests/integration/standard/test_metadata.py w/tests/integration/standard/test_metadata.py
-index bd556f35..c1e9760b 100644
---- c/tests/integration/standard/test_metadata.py
-+++ w/tests/integration/standard/test_metadata.py
-@@ -2082,7 +2082,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
+diff --git a/tests/integration/standard/test_metadata.py b/tests/integration/standard/test_metadata.py
+index b83df220..8750613a 100644
+--- a/tests/integration/standard/test_metadata.py
++++ b/tests/integration/standard/test_metadata.py
+@@ -2079,7 +2079,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
  
          @test_category metadata
          """
@@ -157,10 +186,10 @@ index bd556f35..c1e9760b 100644
  
          self.session.execute("ALTER MATERIALIZED VIEW {0}.mv1 WITH compaction = {{ 'class' : 'LeveledCompactionStrategy' }}".format(self.keyspace_name))
          self.assertIn("LeveledCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
-diff --git c/tests/integration/standard/test_prepared_statements.py w/tests/integration/standard/test_prepared_statements.py
-index 5c79f273..0173763d 100644
---- c/tests/integration/standard/test_prepared_statements.py
-+++ w/tests/integration/standard/test_prepared_statements.py
+diff --git a/tests/integration/standard/test_prepared_statements.py b/tests/integration/standard/test_prepared_statements.py
+index a643b19c..bbde2aff 100644
+--- a/tests/integration/standard/test_prepared_statements.py
++++ b/tests/integration/standard/test_prepared_statements.py
 @@ -168,7 +168,7 @@ class PreparedStatementTests(unittest.TestCase):
      def _run_too_many_bind_values(self, session):
          statement_to_prepare = """ INSERT INTO test3rf.test (v) VALUES  (?)"""

--- a/versions/scylla/3.26.0/ignore.yaml
+++ b/versions/scylla/3.26.0/ignore.yaml
@@ -1,0 +1,67 @@
+# Last verified state on Dec 21, 2018 by Roy Dahan
+tests:
+  ignore:
+    - tests.integration.standard.test_cluster.ClusterTests.test_compact_option
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_string
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+    - tests.integration.standard.test_prepared_statements.PreparedStatementTests.test_imprecise_bind_values_dicts
+    - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider
+v4_tests:
+  ignore:
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_basic
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_custom_payload
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace_and_custom_payload
+    - tests.integration.standard.test_cluster.ClusterTests.test_compact_option
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_basic
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_batching
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_prepared
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_schema_metadata
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_aggregate_metadata
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_function_metadata
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_cql_called_on_null
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_no_parameters
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_same_name_diff_types
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_after_udt
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_string
+    - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_after_functions
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_cql_optional_params
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_init_cond
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_return_type_meta
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_same_name_diff_types
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed

--- a/versions/scylla/3.26.0/patch.patch
+++ b/versions/scylla/3.26.0/patch.patch
@@ -1,0 +1,364 @@
+diff --git a/tests/integration/__init__.py b/tests/integration/__init__.py
+index 7530e874..47d47c8e 100644
+--- a/tests/integration/__init__.py
++++ b/tests/integration/__init__.py
+@@ -42,6 +42,7 @@ from cassandra.protocol import ConfigurationException
+ from cassandra import ProtocolVersion
+ 
+ try:
++    import ccmlib
+     from ccmlib.dse_cluster import DseCluster
+     from ccmlib.cluster import Cluster as CCMCluster
+     from ccmlib.scylla_cluster import ScyllaCluster as CCMScyllaCluster
+@@ -96,6 +97,12 @@ def get_server_versions():
+     return (cass_version, cql_version)
+ 
+ 
++def get_scylla_version(scylla_ccm_version_string):
++    """ get scylla version from ccm before starting a cluster"""
++    ccm_repo_cache_dir, _ = ccmlib.scylla_repository.setup(version=scylla_ccm_version_string)
++    return  ccmlib.common.get_version_from_build(ccm_repo_cache_dir)
++
++
+ def _tuple_version(version_string):
+     if '-' in version_string:
+         version_string = version_string[:version_string.index('-')]
+@@ -366,7 +373,7 @@ greaterthanorequaldse50 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Ver
+ lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1'), "DSE version less than 5.1 required")
+ lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
+ 
+-requirescollectionindexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(SCYLLA_VERSION.split(':')[1]) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
++requirescollectionindexes = unittest.skipUnless(SCYLLA_VERSION is None or Version(get_scylla_version(SCYLLA_VERSION)) >= Version('5.2'), 'Test requires Scylla >= 5.2 or Cassandra')
+ requirescustomindexes = unittest.skipUnless(SCYLLA_VERSION is None, 'Currently, Scylla does not support SASI or any other CUSTOM INDEX class.')
+ 
+ pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
+diff --git a/tests/integration/standard/test_authentication_misconfiguration.py b/tests/integration/standard/test_authentication_misconfiguration.py
+index bb67c987..a8cb9396 100644
+--- a/tests/integration/standard/test_authentication_misconfiguration.py
++++ b/tests/integration/standard/test_authentication_misconfiguration.py
+@@ -38,7 +38,6 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
+ 
+             cls.ccm_cluster = ccm_cluster
+ 
+-    @unittest.expectedFailure
+     def test_connect_no_auth_provider(self):
+         cluster = TestCluster()
+         cluster.connect()
+diff --git a/tests/integration/standard/test_client_warnings.py b/tests/integration/standard/test_client_warnings.py
+index 148c2b11..4aed3724 100644
+--- a/tests/integration/standard/test_client_warnings.py
++++ b/tests/integration/standard/test_client_warnings.py
+@@ -27,7 +27,6 @@ def setup_module():
+ 
+ # Failing with scylla because there is no warning message when changing the value of 'batch_size_warn_threshold_in_kb'
+ # config")
+-@unittest.expectedFailure
+ class ClientWarningTests(unittest.TestCase):
+ 
+     @classmethod
+diff --git a/tests/integration/standard/test_cluster.py b/tests/integration/standard/test_cluster.py
+index 76978038..636729a1 100644
+--- a/tests/integration/standard/test_cluster.py
++++ b/tests/integration/standard/test_cluster.py
+@@ -290,7 +290,6 @@ class ClusterTests(unittest.TestCase):
+         cluster.shutdown()
+ 
+     # "Failing with scylla because there is option to create a cluster with 'lower bound' protocol
+-    @unittest.expectedFailure
+     def test_invalid_protocol_negotation(self):
+         """
+         Test for protocol negotiation when explicit versions are set
+@@ -1229,7 +1228,6 @@ class ClusterTests(unittest.TestCase):
+     @greaterthanorequalcass30
+     @lessthanorequalcass40
+     # The scylla failed because 'Unknown identifier column1'
+-    @unittest.expectedFailure
+     def test_compact_option(self):
+         """
+         Test the driver can connect with the no_compact option and the results
+diff --git a/tests/integration/standard/test_custom_cluster.py b/tests/integration/standard/test_custom_cluster.py
+index d0f10d51..d8353ec3 100644
+--- a/tests/integration/standard/test_custom_cluster.py
++++ b/tests/integration/standard/test_custom_cluster.py
+@@ -26,7 +26,7 @@ def setup_module():
+     config_options = {'native_transport_port': 9046}
+     ccm_cluster.set_configuration_options(config_options)
+     # can't use wait_for_binary_proto cause ccm tries on port 9042
+-    ccm_cluster.start(wait_for_binary_proto=False)
++    ccm_cluster.start(wait_for_binary_proto=True)
+     # wait until all nodes are up
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+     wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
+diff --git a/tests/integration/standard/test_custom_payload.py b/tests/integration/standard/test_custom_payload.py
+index 20efe1c7..11896f02 100644
+--- a/tests/integration/standard/test_custom_payload.py
++++ b/tests/integration/standard/test_custom_payload.py
+@@ -43,7 +43,6 @@ class CustomPayloadTests(unittest.TestCase):
+         self.cluster.shutdown()
+ 
+     # Scylla error: 'truncated frame: expected 65540 bytes, length is 64'
+-    @unittest.expectedFailure
+     def test_custom_query_basic(self):
+         """
+         Test to validate that custom payloads work with simple queries
+@@ -67,7 +66,6 @@ class CustomPayloadTests(unittest.TestCase):
+         self.validate_various_custom_payloads(statement=statement)
+ 
+     # Scylla error: 'Invalid query kind in BATCH messages. Must be 0 or 1 but got 4'"
+-    @unittest.expectedFailure
+     def test_custom_query_batching(self):
+         """
+         Test to validate that custom payloads work with batch queries
+@@ -94,7 +92,6 @@ class CustomPayloadTests(unittest.TestCase):
+ 
+     # Scylla error: 'Got different query ID in server response (b'\x00') than we had before
+     # (b'\x84P\xd0K0\xe2=\x11\xba\x02\x16W\xfatN\xf1')'")
+-    @unittest.expectedFailure
+     def test_custom_query_prepared(self):
+         """
+         Test to validate that custom payloads work with prepared queries
+diff --git a/tests/integration/standard/test_custom_protocol_handler.py b/tests/integration/standard/test_custom_protocol_handler.py
+index 3ec94b05..7443ce07 100644
+--- a/tests/integration/standard/test_custom_protocol_handler.py
++++ b/tests/integration/standard/test_custom_protocol_handler.py
+@@ -121,7 +121,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+         self.assertEqual(len(CustomResultMessageTracked.checked_rev_row_set), len(PRIMITIVE_DATATYPES)-1)
+         cluster.shutdown()
+ 
+-    @unittest.expectedFailure
+     @requirecassandra
+     @greaterthanorequalcass40
+     def test_protocol_divergence_v5_fail_by_continuous_paging(self):
+@@ -169,7 +168,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+         self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.V4, uses_int_query_flag=False,
+                                                         int_flag=True)
+ 
+-    @unittest.expectedFailure
+     @requirecassandra
+     @greaterthanorequalcass40
+     def test_protocol_v5_uses_flag_int(self):
+@@ -197,7 +195,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+         self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.DSE_V1, uses_int_query_flag=True,
+                                                         int_flag=True)
+ 
+-    @unittest.expectedFailure
+     @requirecassandra
+     @greaterthanorequalcass40
+     def test_protocol_divergence_v5_fail_by_flag_uses_int(self):
+diff --git a/tests/integration/standard/test_metadata.py b/tests/integration/standard/test_metadata.py
+index eef89b64..695e74c6 100644
+--- a/tests/integration/standard/test_metadata.py
++++ b/tests/integration/standard/test_metadata.py
+@@ -474,7 +474,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         tablemeta = self.get_table_metadata()
+         self.check_create_statement(tablemeta, create_statement)
+ 
+-    @unittest.expectedFailure
+     def test_indexes(self):
+         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
+         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
+@@ -500,7 +499,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         self.assertIn('CREATE INDEX e_index', statement)
+ 
+     @greaterthancass21
+-    @unittest.expectedFailure
+     def test_collection_indexes(self):
+ 
+         self.session.execute("CREATE TABLE %s.%s (a int PRIMARY KEY, b map<text, text>)"
+@@ -530,7 +528,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+             tablemeta = self.get_table_metadata()
+             self.assertIn('(full(b))', tablemeta.export_as_string())
+ 
+-    @unittest.expectedFailure
+     def test_compression_disabled(self):
+         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
+         create_statement += " WITH compression = {}"
+@@ -565,7 +562,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+             self.assertNotIn("min_threshold", cql)
+             self.assertNotIn("max_threshold", cql)
+ 
+-    @unittest.expectedFailure
+     def test_refresh_schema_metadata(self):
+         """
+         test for synchronously refreshing all cluster metadata
+@@ -838,7 +834,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+             self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
+             cluster.shutdown()
+ 
+-    @unittest.expectedFailure
+     def test_refresh_user_function_metadata(self):
+         """
+         test for synchronously refreshing UDF metadata in keyspace
+@@ -875,7 +870,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+ 
+         cluster2.shutdown()
+ 
+-    @unittest.expectedFailure
+     def test_refresh_user_aggregate_metadata(self):
+         """
+         test for synchronously refreshing UDA metadata in keyspace
+@@ -919,7 +913,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         cluster2.shutdown()
+ 
+     @greaterthanorequalcass30
+-    @unittest.expectedFailure
+     def test_multiple_indices(self):
+         """
+         test multiple indices on the same column.
+@@ -1207,7 +1200,6 @@ CREATE TABLE export_udts.users (
+         cluster.shutdown()
+ 
+     @greaterthancass21
+-    @unittest.expectedFailure
+     def test_case_sensitivity(self):
+         """
+         Test that names that need to be escaped in CREATE statements are
+@@ -1277,7 +1269,6 @@ CREATE TABLE export_udts.users (
+         cluster.shutdown()
+ 
+     @local
+-    @unittest.expectedFailure
+     def test_replicas(self):
+         """
+         Ensure cluster.metadata.get_replicas return correctly when not attached to keyspace
+@@ -1544,7 +1535,6 @@ class FunctionTest(unittest.TestCase):
+             super(FunctionTest.VerifiedAggregate, self).__init__(test_case, Aggregate, test_case.keyspace_aggregate_meta, **kwargs)
+ 
+ 
+-@unittest.expectedFailure
+ class FunctionMetadata(FunctionTest):
+ 
+     def make_function_kwargs(self, called_on_null=True):
+@@ -1743,7 +1733,6 @@ class AggregateMetadata(FunctionTest):
+                 'return_type': "does not matter for creation",
+                 'deterministic': False}
+ 
+-    @unittest.expectedFailure
+     def test_return_type_meta(self):
+         """
+         Test to verify to that the return type of a an aggregate is honored in the metadata
+@@ -1761,7 +1750,6 @@ class AggregateMetadata(FunctionTest):
+         with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('sum_int', 'int', init_cond='1')) as va:
+             self.assertEqual(self.keyspace_aggregate_meta[va.signature].return_type, 'int')
+ 
+-    @unittest.expectedFailure
+     def test_init_cond(self):
+         """
+         Test to verify that various initial conditions are correctly surfaced in various aggregate functions
+@@ -1812,7 +1800,6 @@ class AggregateMetadata(FunctionTest):
+                 self.assertDictContainsSubset(init_not_updated, map_res)
+         c.shutdown()
+ 
+-    @unittest.expectedFailure
+     def test_aggregates_after_functions(self):
+         """
+         Test to verify that aggregates are listed after function in metadata
+@@ -1835,7 +1822,6 @@ class AggregateMetadata(FunctionTest):
+             self.assertNotIn(-1, (aggregate_idx, func_idx), "AGGREGATE or FUNCTION not found in keyspace_cql: " + keyspace_cql)
+             self.assertGreater(aggregate_idx, func_idx)
+ 
+-    @unittest.expectedFailure
+     def test_same_name_diff_types(self):
+         """
+         Test to verify to that aggregates with different signatures are differentiated in metadata
+@@ -1858,7 +1844,6 @@ class AggregateMetadata(FunctionTest):
+                 self.assertEqual(len(aggregates), 2)
+                 self.assertNotEqual(aggregates[0].argument_types, aggregates[1].argument_types)
+ 
+-    @unittest.expectedFailure
+     def test_aggregates_follow_keyspace_alter(self):
+         """
+         Test to verify to that aggregates maintain equality after a keyspace is altered
+@@ -1883,7 +1868,6 @@ class AggregateMetadata(FunctionTest):
+             finally:
+                 self.session.execute('ALTER KEYSPACE %s WITH durable_writes = true' % self.keyspace_name)
+ 
+-    @unittest.expectedFailure
+     def test_cql_optional_params(self):
+         """
+         Test to verify that the initial_cond and final_func parameters are correctly honored
+@@ -2018,7 +2002,6 @@ class BadMetaTest(unittest.TestCase):
+             self.assertIn("/*\nWarning:", m.export_as_string())
+ 
+     @greaterthancass21
+-    @unittest.expectedFailure
+     def test_bad_user_function(self):
+         self.session.execute("""CREATE FUNCTION IF NOT EXISTS %s (key int, val int)
+                                 RETURNS NULL ON NULL INPUT
+@@ -2037,7 +2020,6 @@ class BadMetaTest(unittest.TestCase):
+                 self.assertIn("/*\nWarning:", m.export_as_string())
+ 
+     @greaterthancass21
+-    @unittest.expectedFailure
+     def test_bad_user_aggregate(self):
+         self.session.execute("""CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
+                                 RETURNS NULL ON NULL INPUT
+@@ -2058,7 +2040,6 @@ class BadMetaTest(unittest.TestCase):
+ 
+ class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
+ 
+-    @unittest.expectedFailure
+     def test_dct_alias(self):
+         """
+         Tests to make sure DCT's have correct string formatting
+@@ -2141,7 +2122,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
+ 
+         @test_category metadata
+         """
+-        self.assertIn("SizeTieredCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
++        self.assertIn(self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"], ["SizeTieredCompactionStrategy", "IncrementalCompactionStrategy"])
+ 
+         self.session.execute("ALTER MATERIALIZED VIEW {0}.mv1 WITH compaction = {{ 'class' : 'LeveledCompactionStrategy' }}".format(self.keyspace_name))
+         self.assertIn("LeveledCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
+diff --git a/tests/integration/standard/test_query.py b/tests/integration/standard/test_query.py
+index 7eb4cd39..697dd927 100644
+--- a/tests/integration/standard/test_query.py
++++ b/tests/integration/standard/test_query.py
+@@ -957,7 +957,6 @@ class LightweightTransactionTests(unittest.TestCase):
+         self.assertTrue(received_timeout)
+ 
+     # Failed on Scylla because error `SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time`
+-    @unittest.expectedFailure
+     def test_was_applied_batch_stmt(self):
+         """
+         Test to ensure `:attr:cassandra.cluster.ResultSet.was_applied` works as expected
+@@ -1044,7 +1043,6 @@ class LightweightTransactionTests(unittest.TestCase):
+             results.was_applied
+ 
+     # Skipping until PYTHON-943 is resolved
+-    @unittest.expectedFailure
+     def test_was_applied_batch_string(self):
+         batch_statement = BatchStatement(BatchType.LOGGED)
+         batch_statement.add_all(["INSERT INTO test3rf.lwt_clustering (k, c, v) VALUES (0, 0, 10);",
+@@ -1468,7 +1466,6 @@ class QueryKeyspaceTests(BaseKeyspaceTests):
+ 
+ @greaterthanorequalcass40
+ class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
+-    @unittest.expectedFailure
+     def test_lower_protocol(self):
+         cluster = TestCluster(protocol_version=ProtocolVersion.V4)
+         session = cluster.connect(self.ks_name)
+diff --git a/tests/integration/standard/test_shard_aware.py b/tests/integration/standard/test_shard_aware.py
+index ef2348d1..3c168a15 100644
+--- a/tests/integration/standard/test_shard_aware.py
++++ b/tests/integration/standard/test_shard_aware.py
+@@ -188,7 +188,6 @@ class TestShardAwareIntegration(unittest.TestCase):
+         time.sleep(10)
+         self.query_data(self.session)
+ 
+-    @unittest.expectedFailure
+     def test_blocking_connections(self):
+         """
+         Verify that reconnection is working as expected, when connection are being blocked.
+diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
+index aeec4199..6e2e9f73 100644
+--- a/tests/integration/standard/test_types.py
++++ b/tests/integration/standard/test_types.py
+@@ -731,7 +731,6 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+         s.execute(u"SELECT * FROM system.local WHERE key = 'ef\u2052ef'")
+         s.execute(u"SELECT * FROM system.local WHERE key = %s", (u"fe\u2051fe",))
+ 
+-    @unittest.expectedFailure
+     def test_can_read_composite_type(self):
+         """
+         Test to ensure that CompositeTypes can be used in a query


### PR DESCRIPTION
- Introduce a function to get scylla version correctly
- Introduce cluster cleanups for datastax versions

Fixes: #54
Fixes: #53

## Testing:
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/python-driver-matrix-test/18/