### PR TITLE
Dockerfile: change from jvm8 to jvm11

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ All repositories should be under the **same base folder**
 #### Uploading docker images
 When doing changes to `requirements.txt`, or any other change to docker image, it can be uploaded like this:
 ```bash
-    export MATRIX_DOCKER_IMAGE=scylladb/scylla-python-driver-matrix:python3.8-$(date +'%Y%m%d')
+    export MATRIX_DOCKER_IMAGE=scylladb/scylla-python-driver-matrix:python3.11-$(date +'%Y%m%d')
     docker build ./scripts -t ${MATRIX_DOCKER_IMAGE}
     docker push ${MATRIX_DOCKER_IMAGE}
     echo "${MATRIX_DOCKER_IMAGE}" > scripts/image

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.11-slim-buster
 
 RUN apt-get update \
     && apt-get -y install \
@@ -14,10 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get -y update \
-    && apt-get -y install software-properties-common \
-    && apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
-    && apt-get -y update \
-    && apt-get -y install openjdk-8-jdk-headless libev4 libev-dev patch gcc git procps python2 docker-ce-cli \
+    && apt-get -y install openjdk-11-jdk-headless libev4 libev-dev patch gcc git procps python2 docker-ce-cli \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/image
+++ b/scripts/image
@@ -1,1 +1,1 @@
-scylladb/scylla-python-driver-matrix:python3.8-20220830
+scylladb/scylla-python-driver-matrix:python3.11-20230615


### PR DESCRIPTION
* cause of issue with scylla master, we should swith to jvm11
* update the base image to python 3.11

Fixes: #58