### PR TITLE
datastax,scylla: Add patch for strict_is_not_null_in_views config value

### DIFF
--- a/versions/datastax/3.26.0/patch.patch
+++ b/versions/datastax/3.26.0/patch.patch
@@ -12,7 +12,7 @@ index 996cf434..d51c4895 100644
  sure
  pure-sasl
 diff --git a/tests/integration/__init__.py b/tests/integration/__init__.py
-index a344931a..addda3a5 100644
+index a344931a..56ce6f15 100644
 --- a/tests/integration/__init__.py
 +++ b/tests/integration/__init__.py
 @@ -33,6 +33,7 @@ from itertools import groupby
@@ -74,7 +74,7 @@ index a344931a..addda3a5 100644
                      print("node workloads don't match creating new cluster")
                      return False
              return True
-@@ -563,8 +572,12 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+@@ -563,8 +572,13 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
  
                  CCM_CLUSTER.set_dse_configuration_options(dse_options)
              else:
@@ -83,13 +83,14 @@ index a344931a..addda3a5 100644
 +                if SCYLLA_VERSION:
 +                    CCM_CLUSTER = CCMScyllaCluster(path, cluster_name, **ccm_options)
 +                    CCM_CLUSTER.set_configuration_options({'experimental_features': ['udf']})
++                    CCM_CLUSTER.set_configuration_options({"strict_is_not_null_in_views": False})
 +                else:
 +                    CCM_CLUSTER = CCMCluster(path, cluster_name, **ccm_options)
 +                    CCM_CLUSTER.set_configuration_options({'start_native_transport': True})
                  if Version(cassandra_version) >= Version('2.2'):
                      CCM_CLUSTER.set_configuration_options({'enable_user_defined_functions': True})
                      if Version(cassandra_version) >= Version('3.0'):
-@@ -577,18 +590,18 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+@@ -577,18 +591,18 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
                              })
                  common.switch_cluster(path, cluster_name)
                  CCM_CLUSTER.set_configuration_options(configuration_options)

--- a/versions/scylla/3.25.2/patch.patch
+++ b/versions/scylla/3.25.2/patch.patch
@@ -1,3 +1,18 @@
+diff --git a/tests/integration/__init__.py b/tests/integration/__init__.py
+index cc852898..e728bc77 100644
+--- a/tests/integration/__init__.py
++++ b/tests/integration/__init__.py
+@@ -612,6 +612,10 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+                     # Selecting only features we need for tests, i.e. anything but CDC.
+                     CCM_CLUSTER = CCMScyllaCluster(path, cluster_name, **ccm_options)
+                     CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf'], 'start_native_transport': True})
++
++                    # Permit IS NOT NULL restriction on non-primary key columns of a materialized view
++                    # This allows `test_metadata_with_quoted_identifiers` to run
++                    CCM_CLUSTER.set_configuration_options({'strict_is_not_null_in_views': False})
+                 else:
+                     CCM_CLUSTER = CCMCluster(path, cluster_name, **ccm_options)
+                     CCM_CLUSTER.set_configuration_options({'start_native_transport': True})
 diff --git a/tests/integration/standard/test_authentication_misconfiguration.py b/tests/integration/standard/test_authentication_misconfiguration.py
 index bb67c987..a8cb9396 100644
 --- a/tests/integration/standard/test_authentication_misconfiguration.py

--- a/versions/scylla/3.26.3/patch.patch
+++ b/versions/scylla/3.26.3/patch.patch
@@ -32,6 +32,17 @@ index cc852898..5d20ecd1 100644
                                                reason='Scylla supports collection indexes from 5.2 onwards') 
  requires_custom_indexes = pytest.mark.skipif(SCYLLA_VERSION is not None,
                                            reason='Scylla does not support SASI or any other CUSTOM INDEX class')
+@@ -612,6 +612,10 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None,
+                     # Selecting only features we need for tests, i.e. anything but CDC.
+                     CCM_CLUSTER = CCMScyllaCluster(path, cluster_name, **ccm_options)
+                     CCM_CLUSTER.set_configuration_options({'experimental_features': ['lwt', 'udf'], 'start_native_transport': True})
++
++                    # Permit IS NOT NULL restriction on non-primary key columns of a materialized view
++                    # This allows `test_metadata_with_quoted_identifiers` to run
++                    CCM_CLUSTER.set_configuration_options({'strict_is_not_null_in_views': False})
+                 else:
+                     CCM_CLUSTER = CCMCluster(path, cluster_name, **ccm_options)
+                     CCM_CLUSTER.set_configuration_options({'start_native_transport': True})
 diff --git a/tests/integration/standard/test_client_warnings.py b/tests/integration/standard/test_client_warnings.py
 index 6d5e040e..79df77fe 100644
 --- a/tests/integration/standard/test_client_warnings.py


### PR DESCRIPTION
This change sets strict_is_not_null_in_views to False in cluster
configuration to avoid problems with `test_metadata_with_quoted_identifiers`
test.
