### PR TITLE
docker image to run test ontop python 3.12

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.12-slim-bullseye
 
 RUN apt-get update \
     && apt-get -y install \
@@ -14,7 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get -y update \
-    && apt-get -y install openjdk-11-jdk-headless libev4 libev-dev patch gcc git procps python2 docker-ce-cli \
+    && apt-get -y install openjdk-11-jdk-headless libev4 libev-dev patch gcc git procps docker-ce-cli \
     && pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/image
+++ b/scripts/image
@@ -1,1 +1,1 @@
-scylladb/scylla-python-driver-matrix:python3.9-20230618
+docker.io/scylladb/scylla-python-driver-matrix:python3.9-20231226

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,17 +1,5 @@
 six>=1.6
 pytest==6.2.5
-PyYAML==5.4
-packaging==19.0
-scales==1.0.9
-mock==4.0.3
-pytz==2019.1
-sure==1.4.11
-psutil==5.6.6
-pure-sasl==0.6.1
-Twisted==23.8.0
-unittest2==1.1.0 ; python_version < '3'
-gevent>=1.0
-greenlet
-cython
+PyYAML==6.0.1
 jinja2==3.0.3
 boto3==1.20.51


### PR DESCRIPTION
since we now have driver versions that support python3.12 we should switch to using that

those include
- switch to newer debian bullseye based image (couldn't move to debian bookworm, since openjdk-11 is depracted, and scylla-jmx won't work on 17)
- remove of python2 installation (so it won't support scylla <5.4 <2024.1)
- only scylla 3.26.4 and 3.29.0 and up supports python 3.12