### PR TITLE
run.py: lock pytest version to 7.4.4

### DIFF
--- a/run.py
+++ b/run.py
@@ -121,7 +121,7 @@ class Run:
 
     @lru_cache(maxsize=None)
     def _create_venv(self):
-        basic_packages = ("pytest",
+        basic_packages = ("pytest==7.4.4",
                           "https://github.com/scylladb/scylla-ccm/archive/master.zip",
                           "pytest-subtests")
         if self._venv_path.exists() and self._venv_path.is_dir():


### PR DESCRIPTION
This commit fixes an issue where a slew of AuthenticationTests fails
due to scylla being killed during setup phase.
