### PR TITLE
scripts/run_test.sh: create `~/.shiv` as tmpfs

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -127,6 +127,7 @@ docker_cmd="docker run --detach=true \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     ${group_args[@]} \
     --tmpfs ${HOME}/.cache \
+     --tmpfs ${HOME}/.shiv \
     --tmpfs ${HOME}/.config \
     --tmpfs ${HOME}/.cassandra \
     -v ${HOME}/.local:${HOME}/.local \


### PR DESCRIPTION
since cqlsh move to use shiv, it's using
this folder `~/.shiv` as a place to extract

in this docker envirment, it didn't exist, and
the user didn't had premission to create it.

mounting it as tmpfs fixes the issue.