### PR TITLE
Introduce 3.29.4 patch

### DIFF
--- a/versions/scylla/3.29.4/ignore.yaml
+++ b/versions/scylla/3.29.4/ignore.yaml
@@ -1,0 +1,70 @@
+# Last verified state on Dec 21, 2018 by Roy Dahan
+tests:
+  ignore:
+    - tests.integration.standard.test_cluster.ClusterTests.test_compact_option
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_string
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+    - tests.integration.standard.test_prepared_statements.PreparedStatementTests.test_imprecise_bind_values_dicts
+    - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider
+    - tests.integration.standard.test_cluster.ClusterTests.test_idle_heartbeat
+
+v4_tests:
+  ignore:
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_basic
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_custom_payload
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace
+    - tests.integration.standard.test_client_warnings.ClientWarningTests.test_warning_with_trace_and_custom_payload
+    - tests.integration.standard.test_cluster.ClusterTests.test_compact_option
+    - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_basic
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_batching
+    - tests.integration.standard.test_custom_payload.CustomPayloadTests.test_custom_query_prepared
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_compression_disabled
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_schema_metadata
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_aggregate_metadata
+    - tests.integration.standard.test_metadata.SchemaMetadataTests.test_refresh_user_function_metadata
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_cql_called_on_null
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_no_parameters
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_function_same_name_diff_types
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_after_udt
+    - tests.integration.standard.test_metadata.FunctionMetadata.test_functions_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
+    - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
+    - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
+    - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_string
+    - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_after_functions
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_follow_keyspace_alter
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_cql_optional_params
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_init_cond
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_return_type_meta
+    - tests.integration.standard.test_metadata.AggregateMetadata.test_same_name_diff_types
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warning_default_consistency_level
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
+    - tests.integration.standard.test_authentication_misconfiguration.MisconfiguredAuthenticationTests.test_connect_no_auth_provider
+  flaky:
+    - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
+    - tests.integration.standard.test_cluster.ClusterTests.test_idle_heartbeat


### PR DESCRIPTION
All patches are invalid due to:
1. Test been deleted
2. Patch was merged to the driver

So, we don't need driver anymore