### PR TITLE
Mark compact storag tests in scylla 3.28.0

### DIFF
--- a/versions/scylla/3.28.0/patch.patch
+++ b/versions/scylla/3.28.0/patch.patch
@@ -1,18 +1,56 @@
+diff --git a/tests/integration/__init__.py b/tests/integration/__init__.py
+index 693ce4079..ca80566c2 100644
+--- a/tests/integration/__init__.py
++++ b/tests/integration/__init__.py
+@@ -32,6 +32,7 @@ import platform
+ from threading import Event
+ from subprocess import call
+ from itertools import groupby
++from typing import Callable
+ import shutil
+ import pytest
+ 
+@@ -351,6 +352,15 @@ def local_decorator_creator():
+ 
+     return _id_and_mark
+ 
++
++def xfail_scylla_version(filter: Callable[[Version], bool], reason: str, *args, **kwargs):
++    if SCYLLA_VERSION is None:
++        return pytest.mark.skipif(False, reason="It is just a NoOP Decor, should not skip anything")
++    current_version = Version(get_scylla_version(SCYLLA_VERSION))
++
++    return pytest.mark.xfail(filter(current_version), reason=reason, *args, **kwargs)
++
++
+ local = local_decorator_creator()
+ notprotocolv1 = unittest.skipUnless(PROTOCOL_VERSION > 1, 'Protocol v1 not supported')
+ lessthenprotocolv4 = unittest.skipUnless(PROTOCOL_VERSION < 4, 'Protocol versions 4 or greater not supported')
+@@ -403,6 +413,7 @@ requirecassandra = unittest.skipIf(DSE_VERSION, "Cassandra required")
+ notdse = unittest.skipIf(DSE_VERSION, "DSE not supported")
+ requiredse = unittest.skipUnless(DSE_VERSION, "DSE required")
+ requirescloudproxy = unittest.skipIf(CLOUD_PROXY_PATH is None, "Cloud Proxy path hasn't been specified")
++requirescompactstorage = xfail_scylla_version(lambda v: v >= Version('2025.1.0'), reason="ScyllaDB deprecated compact storage", raises=InvalidRequest)
+ 
+ libevtest = unittest.skipUnless(EVENT_LOOP_MANAGER=="libev", "Test timing designed for libev loop")
+ 
 diff --git a/tests/integration/standard/test_client_warnings.py b/tests/integration/standard/test_client_warnings.py
-index 6d5e040e..79df77fe 100644
+index ce5332a59..6592eb841 100644
 --- a/tests/integration/standard/test_client_warnings.py
 +++ b/tests/integration/standard/test_client_warnings.py
-@@ -28,5 +28,4 @@ def setup_module():
+@@ -24,7 +24,6 @@ from tests.integration import (use_singledc, PROTOCOL_VERSION, local, TestCluste
+ def setup_module():
+     use_singledc()
  
 -@xfail_scylla('scylladb/scylladb#10196 - scylla does not report warnings')
  class ClientWarningTests(unittest.TestCase):
  
      @classmethod
 diff --git a/tests/integration/standard/test_cluster.py b/tests/integration/standard/test_cluster.py
-index 43356dbd..b27c1cd6 100644
+index a0354982e..d7885526b 100644
 --- a/tests/integration/standard/test_cluster.py
 +++ b/tests/integration/standard/test_cluster.py
-@@ -1226,7 +1225,6 @@ class ClusterTests(unittest.TestCase):
+@@ -1225,7 +1225,6 @@ class ClusterTests(unittest.TestCase):
  
      @greaterthanorequalcass30
      @lessthanorequalcass40
@@ -21,10 +59,10 @@ index 43356dbd..b27c1cd6 100644
          """
          Test the driver can connect with the no_compact option and the results
 diff --git a/tests/integration/standard/test_custom_protocol_handler.py b/tests/integration/standard/test_custom_protocol_handler.py
-index 3ec94b05..7443ce07 100644
+index 9d9f90e63..000b1d4cf 100644
 --- a/tests/integration/standard/test_custom_protocol_handler.py
 +++ b/tests/integration/standard/test_custom_protocol_handler.py
-@@ -121,7 +121,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+@@ -120,7 +120,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
          self.assertEqual(len(CustomResultMessageTracked.checked_rev_row_set), len(PRIMITIVE_DATATYPES)-1)
          cluster.shutdown()
  
@@ -32,7 +70,7 @@ index 3ec94b05..7443ce07 100644
      @requirecassandra
      @greaterthanorequalcass40
      def test_protocol_divergence_v5_fail_by_continuous_paging(self):
-@@ -169,7 +168,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+@@ -168,7 +167,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
          self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.V4, uses_int_query_flag=False,
                                                          int_flag=True)
  
@@ -40,7 +78,7 @@ index 3ec94b05..7443ce07 100644
      @requirecassandra
      @greaterthanorequalcass40
      def test_protocol_v5_uses_flag_int(self):
-@@ -197,7 +195,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
+@@ -196,7 +194,6 @@ class CustomProtocolHandlerTest(unittest.TestCase):
          self._protocol_divergence_fail_by_flag_uses_int(ProtocolVersion.DSE_V1, uses_int_query_flag=True,
                                                          int_flag=True)
  
@@ -49,10 +87,52 @@ index 3ec94b05..7443ce07 100644
      @greaterthanorequalcass40
      def test_protocol_divergence_v5_fail_by_flag_uses_int(self):
 diff --git a/tests/integration/standard/test_metadata.py b/tests/integration/standard/test_metadata.py
-index c561491a..8c37afa0 100644
+index a1d4d405c..b8c919e20 100644
 --- a/tests/integration/standard/test_metadata.py
 +++ b/tests/integration/standard/test_metadata.py
-@@ -476,7 +476,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -42,7 +42,8 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
+                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
+                                greaterthanorequaldse67, lessthancass40,
+                                TestCluster, DSE_VERSION, requires_java_udf, requires_composite_type,
+-                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt)
++                               requires_collection_indexes, SCYLLA_VERSION, xfail_scylla, xfail_scylla_version_lt,
++                               requirescompactstorage)
+ 
+ from tests.util import wait_until
+ 
+@@ -428,6 +429,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         self.check_create_statement(tablemeta, create_statement)
+ 
+     @lessthancass40
++    @requirescompactstorage
+     def test_compact_storage(self):
+         create_statement = self.make_create_statement(["a"], [], ["b"])
+         create_statement += " WITH COMPACT STORAGE"
+@@ -437,6 +439,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         self.check_create_statement(tablemeta, create_statement)
+ 
+     @lessthancass40
++    @requirescompactstorage
+     def test_dense_compact_storage(self):
+         create_statement = self.make_create_statement(["a"], ["b"], ["c"])
+         create_statement += " WITH COMPACT STORAGE"
+@@ -456,6 +459,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         self.check_create_statement(tablemeta, create_statement)
+ 
+     @lessthancass40
++    @requirescompactstorage
+     def test_counter_with_compact_storage(self):
+         """ PYTHON-1100 """
+         create_statement = (
+@@ -468,6 +472,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+         self.check_create_statement(tablemeta, create_statement)
+ 
+     @lessthancass40
++    @requirescompactstorage
+     def test_counter_with_dense_compact_storage(self):
+         create_statement = (
+             "CREATE TABLE {keyspace}.{table} ("
+@@ -478,7 +483,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
          tablemeta = self.get_table_metadata()
          self.check_create_statement(tablemeta, create_statement)
  
@@ -60,7 +140,7 @@ index c561491a..8c37afa0 100644
      def test_indexes(self):
          create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
          create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"
-@@ -502,8 +501,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -504,7 +508,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
          self.assertIn('CREATE INDEX e_index', statement)
  
      @greaterthancass21
@@ -68,8 +148,7 @@ index c561491a..8c37afa0 100644
      @xfail_scylla('scylladb/scylladb#22013 - scylla does not show full index in system_schema.indexes')
      def test_collection_indexes(self):
  
-         self.session.execute("CREATE TABLE %s.%s (a int PRIMARY KEY, b map<text, text>)"
-@@ -568,7 +564,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -571,7 +574,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
              self.assertNotIn("min_threshold", cql)
              self.assertNotIn("max_threshold", cql)
  
@@ -77,7 +156,7 @@ index c561491a..8c37afa0 100644
      def test_refresh_schema_metadata(self):
          """
          test for synchronously refreshing all cluster metadata
-@@ -841,7 +836,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -844,7 +846,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
              self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
              cluster.shutdown()
  
@@ -85,7 +164,7 @@ index c561491a..8c37afa0 100644
      def test_refresh_user_function_metadata(self):
          """
          test for synchronously refreshing UDF metadata in keyspace
-@@ -878,7 +872,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -881,7 +882,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
  
          cluster2.shutdown()
  
@@ -93,7 +172,7 @@ index c561491a..8c37afa0 100644
      def test_refresh_user_aggregate_metadata(self):
          """
          test for synchronously refreshing UDA metadata in keyspace
-@@ -922,7 +915,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -925,7 +925,6 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
          cluster2.shutdown()
  
      @greaterthanorequalcass30
@@ -101,7 +180,7 @@ index c561491a..8c37afa0 100644
      def test_multiple_indices(self):
          """
          test multiple indices on the same column.
-@@ -1210,8 +1202,6 @@ CREATE TABLE export_udts.users (
+@@ -1208,8 +1207,6 @@ CREATE TABLE export_udts.users (
          cluster.shutdown()
  
      @greaterthancass21
@@ -110,7 +189,7 @@ index c561491a..8c37afa0 100644
      def test_case_sensitivity(self):
          """
          Test that names that need to be escaped in CREATE statements are
-@@ -1280,7 +1271,6 @@ CREATE TABLE export_udts.users (
+@@ -1279,7 +1276,6 @@ CREATE TABLE export_udts.users (
          cluster.shutdown()
  
      @local
@@ -118,7 +197,7 @@ index c561491a..8c37afa0 100644
      def test_replicas(self):
          """
          Ensure cluster.metadata.get_replicas return correctly when not attached to keyspace
-@@ -1547,7 +1537,6 @@ class FunctionTest(unittest.TestCase):
+@@ -1578,7 +1574,6 @@ class FunctionTest(unittest.TestCase):
              super(FunctionTest.VerifiedAggregate, self).__init__(test_case, Aggregate, test_case.keyspace_aggregate_meta, **kwargs)
  
  
@@ -126,7 +205,7 @@ index c561491a..8c37afa0 100644
  class FunctionMetadata(FunctionTest):
  
      def make_function_kwargs(self, called_on_null=True):
-@@ -2016,7 +2005,6 @@ class BadMetaTest(unittest.TestCase):
+@@ -2048,7 +2043,6 @@ class BadMetaTest(unittest.TestCase):
              self.assertIn("/*\nWarning:", m.export_as_string())
  
      @greaterthancass21
@@ -134,7 +213,7 @@ index c561491a..8c37afa0 100644
      def test_bad_user_function(self):
          self.session.execute("""CREATE FUNCTION IF NOT EXISTS %s (key int, val int)
                                  RETURNS NULL ON NULL INPUT
-@@ -2035,7 +2023,6 @@ class BadMetaTest(unittest.TestCase):
+@@ -2067,7 +2061,6 @@ class BadMetaTest(unittest.TestCase):
                  self.assertIn("/*\nWarning:", m.export_as_string())
  
      @greaterthancass21
@@ -142,7 +221,7 @@ index c561491a..8c37afa0 100644
      def test_bad_user_aggregate(self):
          self.session.execute("""CREATE FUNCTION IF NOT EXISTS sum_int (key int, val int)
                                  RETURNS NULL ON NULL INPUT
-@@ -2056,7 +2043,6 @@ class BadMetaTest(unittest.TestCase):
+@@ -2088,7 +2081,6 @@ class BadMetaTest(unittest.TestCase):
  
  class DynamicCompositeTypeTest(BasicSharedKeyspaceUnitTestCase):
  
@@ -150,7 +229,7 @@ index c561491a..8c37afa0 100644
      def test_dct_alias(self):
          """
          Tests to make sure DCT's have correct string formatting
-@@ -2139,7 +2125,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
+@@ -2171,7 +2163,7 @@ class MaterializedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
  
          @test_category metadata
          """
@@ -160,10 +239,10 @@ index c561491a..8c37afa0 100644
          self.session.execute("ALTER MATERIALIZED VIEW {0}.mv1 WITH compaction = {{ 'class' : 'LeveledCompactionStrategy' }}".format(self.keyspace_name))
          self.assertIn("LeveledCompactionStrategy", self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views["mv1"].options["compaction"]["class"])
 diff --git a/tests/integration/standard/test_query.py b/tests/integration/standard/test_query.py
-index fdab4e7a..d2d1cc16 100644
+index a2954db26..6af73f067 100644
 --- a/tests/integration/standard/test_query.py
 +++ b/tests/integration/standard/test_query.py
-@@ -951,7 +951,6 @@ class LightweightTransactionTests(unittest.TestCase):
+@@ -950,7 +950,6 @@ class LightweightTransactionTests(unittest.TestCase):
          # Make sure test passed
          self.assertTrue(received_timeout)
  
@@ -171,7 +250,7 @@ index fdab4e7a..d2d1cc16 100644
      def test_was_applied_batch_stmt(self):
          """
          Test to ensure `:attr:cassandra.cluster.ResultSet.was_applied` works as expected
-@@ -1037,7 +1036,6 @@ class LightweightTransactionTests(unittest.TestCase):
+@@ -1036,7 +1035,6 @@ class LightweightTransactionTests(unittest.TestCase):
          with self.assertRaises(RuntimeError):
              results.was_applied
  
@@ -179,7 +258,7 @@ index fdab4e7a..d2d1cc16 100644
      def test_was_applied_batch_string(self):
          batch_statement = BatchStatement(BatchType.LOGGED)
          batch_statement.add_all(["INSERT INTO test3rf.lwt_clustering (k, c, v) VALUES (0, 0, 10);",
-@@ -1461,7 +1459,6 @@ class QueryKeyspaceTests(BaseKeyspaceTests):
+@@ -1460,7 +1458,6 @@ class QueryKeyspaceTests(BaseKeyspaceTests):
  
  @greaterthanorequalcass40
  class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
@@ -188,7 +267,7 @@ index fdab4e7a..d2d1cc16 100644
          cluster = TestCluster(protocol_version=ProtocolVersion.V4)
          session = cluster.connect(self.ks_name)
 diff --git a/tests/integration/standard/test_shard_aware.py b/tests/integration/standard/test_shard_aware.py
-index cf8f17e2..e1e8d653 100644
+index cf8f17e20..e1e8d6533 100644
 --- a/tests/integration/standard/test_shard_aware.py
 +++ b/tests/integration/standard/test_shard_aware.py
 @@ -190,7 +190,6 @@ class TestShardAwareIntegration(unittest.TestCase):
@@ -200,10 +279,10 @@ index cf8f17e2..e1e8d653 100644
          """
          Verify that reconnection is working as expected, when connection are being blocked.
 diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
-index 4329574b..a3fddd74 100644
+index 56b2914ce..a0decd11e 100644
 --- a/tests/integration/standard/test_types.py
 +++ b/tests/integration/standard/test_types.py
-@@ -776,7 +776,6 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+@@ -757,7 +757,6 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
          s.execute(u"SELECT * FROM system.local WHERE key = 'ef\u2052ef'")
          s.execute(u"SELECT * FROM system.local WHERE key = %s", (u"fe\u2051fe",))
  


### PR DESCRIPTION
Compact storage support was disabled in 2025.1.0.
This commit mark compact storage xfail on scylla version after 2025.1.0