### PR TITLE
Move to uv when testing scylla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv*
+.uv/
 
 __pycache__/*
 *.pyc

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## Prerequisites
 * Python3.8
 * pip
+* uv
 * docker
 * git
 * OpenJDK 8
 
 #### Installing dependencies
-Following commands will install all project dependencies using [Pipenv](https:/e/pipenv.readthedocs.io/en/latest/)
+Following commands will install all project dependencies using [uv](https://github.com/astral-sh/uv)
 
 
 * Updates the package sources list
@@ -19,9 +20,9 @@ Following commands will install all project dependencies using [Pipenv](https:/e
   ```bash
   sudo apt-get install -y git-all
   ```
-* `pip` install
+* `uv` install (recommended)
   ```bash
-  sudo apt-get install -y python3-pip
+  curl -LsSf https://astral.sh/uv/install.sh | sh
   ```
 * `python` imported packages (Please note that the default `Python` version should be `3.8`)
    ```bash

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -21,3 +21,7 @@ RUN apt-get -y update \
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+


### PR DESCRIPTION
Tested on jenkins: https://jenkins.scylladb.com/job/scylla-master/job/driver-tests/job/python-driver-matrix-test/2096/
uv installation and running tests works as expected. Two tests are failing but this is a separate issue (test_imprecise_bind_values_dicts and test_client_routes_change_event https://github.com/scylladb/python-driver/issues/652).
Refs: https://github.com/scylladb/python-driver/pull/496