### PR TITLE
Add additional fixes to 3.28.2 patch

### DIFF
--- a/versions/scylla/3.28.2/patch.patch
+++ b/versions/scylla/3.28.2/patch.patch
@@ -339,3 +339,16 @@ index 4d388ed2..630e5e6b 100644
 +from unittest.mock import patch
  import logging
  import sys
+diff --git a/tests/integration/standard/test_prepared_statements.py b/tests/integration/standard/test_prepared_statements.py
+index 5ccc0732..3f63b881 100644
+--- a/tests/integration/standard/test_prepared_statements.py
++++ b/tests/integration/standard/test_prepared_statements.py
+@@ -43,7 +44,7 @@ class PreparedStatementTests(unittest.TestCase):
+         cls.cass_version = get_server_versions()
+
+     def setUp(self):
+-        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True)
++        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True, protocol_version=PROTOCOL_VERSION)
+         self.session = self.cluster.connect()
+
+     def tearDown(self):


### PR DESCRIPTION
Changes:
- Add `test_connection.py` to fix wrong import
- Add `test_prepared_statement.py` to propagate fix from https://github.com/scylladb/python-driver/pull/669