### PR TITLE
Incorporate nesting-depth limit fix into patches

### DIFF
--- a/versions/apache/3.29.3/patch.patch
+++ b/versions/apache/3.29.3/patch.patch
@@ -773,6 +773,34 @@ index 17598758..311d64d2 100644
                                  'replication_factor': '{1}'}}""".format(cls.alternative_ks, 1)
          cls.session.execute(ddl)
  
+diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
+index 55bf117a..6a6576d1 100644
+--- a/tests/integration/standard/test_types.py
++++ b/tests/integration/standard/test_types.py
+@@ -662,18 +662,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
+ 
+         # create a table with multiple sizes of nested tuples
++        # Note: Scylla limits CQL expression nesting depth to 12, so the
++        # deepest tuple tested here is 12 levels deep.
+         s.execute("CREATE TABLE nested_tuples ("
+                   "k int PRIMARY KEY, "
+                   "v_1 frozen<%s>,"
+                   "v_2 frozen<%s>,"
+                   "v_3 frozen<%s>,"
+-                  "v_32 frozen<%s>"
++                  "v_12 frozen<%s>"
+                   ")" % (self.nested_tuples_schema_helper(1),
+                          self.nested_tuples_schema_helper(2),
+                          self.nested_tuples_schema_helper(3),
+-                         self.nested_tuples_schema_helper(32)))
++                         self.nested_tuples_schema_helper(12)))
+ 
+-        for i in (1, 2, 3, 32):
++        for i in (1, 2, 3, 12):
+             # create tuple
+             created_tuple = self.nested_tuples_creator_helper(i)
+ 
 diff --git a/tests/integration/standard/test_udts.py b/tests/integration/standard/test_udts.py
 index ae056d77..574d90ab 100644
 --- a/tests/integration/standard/test_udts.py
@@ -822,3 +850,30 @@ index ae056d77..574d90ab 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
+@@ -392,7 +392,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -420,7 +420,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -457,7 +457,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)

--- a/versions/apache/3.30.0/patch.patch
+++ b/versions/apache/3.30.0/patch.patch
@@ -686,6 +686,34 @@ index 3ede0ac3..da512f8f 100644
  class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
  
      def test_mv_filtering(self):
+diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
+index 3a6de0d4..a188843b 100644
+--- a/tests/integration/standard/test_types.py
++++ b/tests/integration/standard/test_types.py
+@@ -664,18 +664,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
+ 
+         # create a table with multiple sizes of nested tuples
++        # Note: Scylla limits CQL expression nesting depth to 12, so the
++        # deepest tuple tested here is 12 levels deep.
+         s.execute("CREATE TABLE nested_tuples ("
+                   "k int PRIMARY KEY, "
+                   "v_1 frozen<%s>,"
+                   "v_2 frozen<%s>,"
+                   "v_3 frozen<%s>,"
+-                  "v_32 frozen<%s>"
++                  "v_12 frozen<%s>"
+                   ")" % (self.nested_tuples_schema_helper(1),
+                          self.nested_tuples_schema_helper(2),
+                          self.nested_tuples_schema_helper(3),
+-                         self.nested_tuples_schema_helper(32)))
++                         self.nested_tuples_schema_helper(12)))
+ 
+-        for i in (1, 2, 3, 32):
++        for i in (1, 2, 3, 12):
+             # create tuple
+             created_tuple = self.nested_tuples_creator_helper(i)
+ 
 diff --git a/tests/integration/standard/test_udts.py b/tests/integration/standard/test_udts.py
 index 9c3e560b..5b347ce2 100644
 --- a/tests/integration/standard/test_udts.py
@@ -735,3 +763,30 @@ index 9c3e560b..5b347ce2 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
+@@ -394,7 +394,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -422,7 +422,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -459,7 +459,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)

--- a/versions/scylla/3.28.2/patch.patch
+++ b/versions/scylla/3.28.2/patch.patch
@@ -1020,6 +1020,34 @@ index cf8f17e2..b3ca3993 100644
          """
  
          self.create_ks_and_cf()
+diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
+index 56b2914c..4f185dc1 100644
+--- a/tests/integration/standard/test_types.py
++++ b/tests/integration/standard/test_types.py
+@@ -654,18 +654,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
+ 
+         # create a table with multiple sizes of nested tuples
++        # Note: Scylla limits CQL expression nesting depth to 12, so the
++        # deepest tuple tested here is 12 levels deep.
+         s.execute("CREATE TABLE nested_tuples ("
+                   "k int PRIMARY KEY, "
+                   "v_1 frozen<%s>,"
+                   "v_2 frozen<%s>,"
+                   "v_3 frozen<%s>,"
+-                  "v_32 frozen<%s>"
++                  "v_12 frozen<%s>"
+                   ")" % (self.nested_tuples_schema_helper(1),
+                          self.nested_tuples_schema_helper(2),
+                          self.nested_tuples_schema_helper(3),
+-                         self.nested_tuples_schema_helper(32)))
++                         self.nested_tuples_schema_helper(12)))
+ 
+-        for i in (1, 2, 3, 32):
++        for i in (1, 2, 3, 12):
+             # create tuple
+             created_tuple = self.nested_tuples_creator_helper(i)
+ 
 diff --git a/tests/integration/standard/test_udts.py b/tests/integration/standard/test_udts.py
 index 7188bf3e..9b20b1b7 100644
 --- a/tests/integration/standard/test_udts.py
@@ -1068,6 +1096,33 @@ index 7188bf3e..9b20b1b7 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
+@@ -388,7 +388,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -416,7 +416,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -453,7 +453,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
 diff --git a/tests/integration/standard/test_use_keyspace.py b/tests/integration/standard/test_use_keyspace.py
 index 42cf03a5..3021bca2 100644
 --- a/tests/integration/standard/test_use_keyspace.py

--- a/versions/scylla/3.29.10/patch.patch
+++ b/versions/scylla/3.29.10/patch.patch
@@ -445,6 +445,34 @@ index d9691403..45e8a807 100644
  
  
  class TestTabletsIntegration:
+diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
+index 559a6b3d..6bf25ce1 100644
+--- a/tests/integration/standard/test_types.py
++++ b/tests/integration/standard/test_types.py
+@@ -663,18 +663,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
+ 
+         # create a table with multiple sizes of nested tuples
++        # Note: Scylla limits CQL expression nesting depth to 12, so the
++        # deepest tuple tested here is 12 levels deep.
+         s.execute("CREATE TABLE nested_tuples ("
+                   "k int PRIMARY KEY, "
+                   "v_1 frozen<%s>,"
+                   "v_2 frozen<%s>,"
+                   "v_3 frozen<%s>,"
+-                  "v_32 frozen<%s>"
++                  "v_12 frozen<%s>"
+                   ")" % (self.nested_tuples_schema_helper(1),
+                          self.nested_tuples_schema_helper(2),
+                          self.nested_tuples_schema_helper(3),
+-                         self.nested_tuples_schema_helper(32)))
++                         self.nested_tuples_schema_helper(12)))
+ 
+-        for i in (1, 2, 3, 32):
++        for i in (1, 2, 3, 12):
+             # create tuple
+             created_tuple = self.nested_tuples_creator_helper(i)
+ 
 diff --git a/tests/integration/standard/test_udts.py b/tests/integration/standard/test_udts.py
 index 18f3dfb2..11888add 100644
 --- a/tests/integration/standard/test_udts.py
@@ -493,6 +521,33 @@ index 18f3dfb2..11888add 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
+@@ -389,7 +389,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -417,7 +417,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -454,7 +454,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            max_nesting_depth = 12
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
 diff --git a/tests/integration/standard/test_use_keyspace.py b/tests/integration/standard/test_use_keyspace.py
 index 80e7cfe5..9eb3f5be 100644
 --- a/tests/integration/standard/test_use_keyspace.py


### PR DESCRIPTION
Incorporate nesting-depth limit fix into 3.28.2/3.29.10 scylla and 329.3/3.30.0 apache patches

Propagate changes from commit https://github.com/scylladb/python-driver/commit/28ddc074b53d9f4164e64fcd4b87fc307daada51 (reduce nested type/UDT depth to 12 for new CQL nesting limit).