### PR TITLE
Reduce nesting depth in tests to respect server CQL limit

### DIFF
--- a/versions/apache/3.29.3/patch.patch
+++ b/versions/apache/3.29.3/patch.patch
@@ -774,30 +774,32 @@ index 17598758..311d64d2 100644
          cls.session.execute(ddl)
  
 diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
-index 55bf117a..6a6576d1 100644
+index 55bf117a..a6a8d259 100644
 --- a/tests/integration/standard/test_types.py
 +++ b/tests/integration/standard/test_types.py
-@@ -662,18 +662,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+@@ -662,18 +662,22 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
          s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
  
          # create a table with multiple sizes of nested tuples
-+        # Note: Scylla limits CQL expression nesting depth to 12, so the
-+        # deepest tuple tested here is 12 levels deep.
++        # Note: Scylla limits CQL expression nesting depth to 12 (every
++        # recursive `term` counts, including the innermost scalar value), so a
++        # nested tuple literal can be at most 11 levels deep before the server
++        # rejects it with "expression nested too deeply".
          s.execute("CREATE TABLE nested_tuples ("
                    "k int PRIMARY KEY, "
                    "v_1 frozen<%s>,"
                    "v_2 frozen<%s>,"
                    "v_3 frozen<%s>,"
 -                  "v_32 frozen<%s>"
-+                  "v_12 frozen<%s>"
++                  "v_11 frozen<%s>"
                    ")" % (self.nested_tuples_schema_helper(1),
                           self.nested_tuples_schema_helper(2),
                           self.nested_tuples_schema_helper(3),
 -                         self.nested_tuples_schema_helper(32)))
-+                         self.nested_tuples_schema_helper(12)))
++                         self.nested_tuples_schema_helper(11)))
  
 -        for i in (1, 2, 3, 32):
-+        for i in (1, 2, 3, 12):
++        for i in (1, 2, 3, 11):
              # create tuple
              created_tuple = self.nested_tuples_creator_helper(i)
  
@@ -850,7 +852,21 @@ index ae056d77..574d90ab 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
-@@ -392,7 +392,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -392,7 +392,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -420,7 +425,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
@@ -859,21 +875,17 @@ index ae056d77..574d90ab 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -420,7 +420,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -457,7 +462,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
 -            max_nesting_depth = 16
-+            max_nesting_depth = 12
- 
-             # create the schema
-             self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -457,7 +457,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
-         with self._cluster_default_dict_factory() as c:
-             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
- 
--            max_nesting_depth = 16
-+            max_nesting_depth = 12
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)

--- a/versions/apache/3.30.0/patch.patch
+++ b/versions/apache/3.30.0/patch.patch
@@ -687,30 +687,32 @@ index 3ede0ac3..da512f8f 100644
  
      def test_mv_filtering(self):
 diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
-index 3a6de0d4..a188843b 100644
+index 3a6de0d4..ebbbbec7 100644
 --- a/tests/integration/standard/test_types.py
 +++ b/tests/integration/standard/test_types.py
-@@ -664,18 +664,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+@@ -664,18 +664,22 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
          s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
  
          # create a table with multiple sizes of nested tuples
-+        # Note: Scylla limits CQL expression nesting depth to 12, so the
-+        # deepest tuple tested here is 12 levels deep.
++        # Note: Scylla limits CQL expression nesting depth to 12 (every
++        # recursive `term` counts, including the innermost scalar value), so a
++        # nested tuple literal can be at most 11 levels deep before the server
++        # rejects it with "expression nested too deeply".
          s.execute("CREATE TABLE nested_tuples ("
                    "k int PRIMARY KEY, "
                    "v_1 frozen<%s>,"
                    "v_2 frozen<%s>,"
                    "v_3 frozen<%s>,"
 -                  "v_32 frozen<%s>"
-+                  "v_12 frozen<%s>"
++                  "v_11 frozen<%s>"
                    ")" % (self.nested_tuples_schema_helper(1),
                           self.nested_tuples_schema_helper(2),
                           self.nested_tuples_schema_helper(3),
 -                         self.nested_tuples_schema_helper(32)))
-+                         self.nested_tuples_schema_helper(12)))
++                         self.nested_tuples_schema_helper(11)))
  
 -        for i in (1, 2, 3, 32):
-+        for i in (1, 2, 3, 12):
++        for i in (1, 2, 3, 11):
              # create tuple
              created_tuple = self.nested_tuples_creator_helper(i)
  
@@ -763,7 +765,21 @@ index 9c3e560b..5b347ce2 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
-@@ -394,7 +394,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -394,7 +394,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -422,7 +427,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
@@ -772,21 +788,17 @@ index 9c3e560b..5b347ce2 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -422,7 +422,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -459,7 +464,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
 -            max_nesting_depth = 16
-+            max_nesting_depth = 12
- 
-             # create the schema
-             self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -459,7 +459,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
-         with self._cluster_default_dict_factory() as c:
-             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
- 
--            max_nesting_depth = 16
-+            max_nesting_depth = 12
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)

--- a/versions/scylla/3.28.2/patch.patch
+++ b/versions/scylla/3.28.2/patch.patch
@@ -1021,30 +1021,32 @@ index cf8f17e2..b3ca3993 100644
  
          self.create_ks_and_cf()
 diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
-index 56b2914c..4f185dc1 100644
+index 56b2914c..f0dd59d9 100644
 --- a/tests/integration/standard/test_types.py
 +++ b/tests/integration/standard/test_types.py
-@@ -654,18 +654,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+@@ -654,18 +654,22 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
          s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
  
          # create a table with multiple sizes of nested tuples
-+        # Note: Scylla limits CQL expression nesting depth to 12, so the
-+        # deepest tuple tested here is 12 levels deep.
++        # Note: Scylla limits CQL expression nesting depth to 12 (every
++        # recursive `term` counts, including the innermost scalar value), so a
++        # nested tuple literal can be at most 11 levels deep before the server
++        # rejects it with "expression nested too deeply".
          s.execute("CREATE TABLE nested_tuples ("
                    "k int PRIMARY KEY, "
                    "v_1 frozen<%s>,"
                    "v_2 frozen<%s>,"
                    "v_3 frozen<%s>,"
 -                  "v_32 frozen<%s>"
-+                  "v_12 frozen<%s>"
++                  "v_11 frozen<%s>"
                    ")" % (self.nested_tuples_schema_helper(1),
                           self.nested_tuples_schema_helper(2),
                           self.nested_tuples_schema_helper(3),
 -                         self.nested_tuples_schema_helper(32)))
-+                         self.nested_tuples_schema_helper(12)))
++                         self.nested_tuples_schema_helper(11)))
  
 -        for i in (1, 2, 3, 32):
-+        for i in (1, 2, 3, 12):
++        for i in (1, 2, 3, 11):
              # create tuple
              created_tuple = self.nested_tuples_creator_helper(i)
  
@@ -1096,7 +1098,21 @@ index 7188bf3e..9b20b1b7 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
-@@ -388,7 +388,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -388,7 +388,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -416,7 +421,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
@@ -1105,21 +1121,17 @@ index 7188bf3e..9b20b1b7 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -416,7 +416,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -453,7 +458,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
 -            max_nesting_depth = 16
-+            max_nesting_depth = 12
- 
-             # create the schema
-             self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -453,7 +453,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
-         with self._cluster_default_dict_factory() as c:
-             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
- 
--            max_nesting_depth = 16
-+            max_nesting_depth = 12
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)

--- a/versions/scylla/3.29.10/patch.patch
+++ b/versions/scylla/3.29.10/patch.patch
@@ -446,30 +446,32 @@ index d9691403..45e8a807 100644
  
  class TestTabletsIntegration:
 diff --git a/tests/integration/standard/test_types.py b/tests/integration/standard/test_types.py
-index 559a6b3d..6bf25ce1 100644
+index 559a6b3d..d742f84f 100644
 --- a/tests/integration/standard/test_types.py
 +++ b/tests/integration/standard/test_types.py
-@@ -663,18 +663,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
+@@ -663,18 +663,22 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
          s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
  
          # create a table with multiple sizes of nested tuples
-+        # Note: Scylla limits CQL expression nesting depth to 12, so the
-+        # deepest tuple tested here is 12 levels deep.
++        # Note: Scylla limits CQL expression nesting depth to 12 (every
++        # recursive `term` counts, including the innermost scalar value), so a
++        # nested tuple literal can be at most 11 levels deep before the server
++        # rejects it with "expression nested too deeply".
          s.execute("CREATE TABLE nested_tuples ("
                    "k int PRIMARY KEY, "
                    "v_1 frozen<%s>,"
                    "v_2 frozen<%s>,"
                    "v_3 frozen<%s>,"
 -                  "v_32 frozen<%s>"
-+                  "v_12 frozen<%s>"
++                  "v_11 frozen<%s>"
                    ")" % (self.nested_tuples_schema_helper(1),
                           self.nested_tuples_schema_helper(2),
                           self.nested_tuples_schema_helper(3),
 -                         self.nested_tuples_schema_helper(32)))
-+                         self.nested_tuples_schema_helper(12)))
++                         self.nested_tuples_schema_helper(11)))
  
 -        for i in (1, 2, 3, 32):
-+        for i in (1, 2, 3, 12):
++        for i in (1, 2, 3, 11):
              # create tuple
              created_tuple = self.nested_tuples_creator_helper(i)
  
@@ -521,7 +523,21 @@ index 18f3dfb2..11888add 100644
              """)
          s.set_keyspace("udt_test_prepared_registered2")
          s.execute("CREATE TYPE user (state text, is_cool boolean)")
-@@ -389,7 +389,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -389,7 +389,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+         with self._cluster_default_dict_factory() as c:
+             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
+ 
+-            max_nesting_depth = 16
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
+ 
+             # create the schema
+             self.nested_udt_schema_helper(s, max_nesting_depth)
+@@ -417,7 +422,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
@@ -530,21 +546,17 @@ index 18f3dfb2..11888add 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -417,7 +417,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
+@@ -454,7 +459,12 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
          with self._cluster_default_dict_factory() as c:
              s = c.connect(self.keyspace_name, wait_for_all_pools=True)
  
 -            max_nesting_depth = 16
-+            max_nesting_depth = 12
- 
-             # create the schema
-             self.nested_udt_schema_helper(s, max_nesting_depth)
-@@ -454,7 +454,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
-         with self._cluster_default_dict_factory() as c:
-             s = c.connect(self.keyspace_name, wait_for_all_pools=True)
- 
--            max_nesting_depth = 16
-+            max_nesting_depth = 12
++            # Scylla caps CQL expression nesting depth at 12 (every recursive
++            # `term` counts). A UDT literal `{value: ...}` adds two term levels
++            # per nesting, so a UDT literal inserted via a simple statement can
++            # be at most 10 levels deep before the server rejects it with
++            # "expression nested too deeply".
++            max_nesting_depth = 10
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)


### PR DESCRIPTION
Propagate changes from commit bf7966fcad2f98d5a4d0574f6f4a92614e2f7470 (nested tuples max depth 11, nested UDT literals max depth 10) into the 3.28.2/3.29.10 scylla and 3.29.3/3.30.0 apache patches.