### PR TITLE
matrix: install Scylla driver dev dependencies via uv

### DIFF
--- a/run.py
+++ b/run.py
@@ -177,6 +177,10 @@ class Run:
                     self._run_command_in_shell("curl -LsSf https://astral.sh/uv/install.sh | sh")
             self._create_venv()
             pip_prefix = "uv " if self._python_driver_type == "scylla" else ""
+            if self._python_driver_type == "scylla":
+                self._run_command_in_shell(f"{self._activate_venv_cmd()} && "
+                                           "uv sync --active --group dev --inexact")
+                return True
             for requirement_file in ["requirements.txt", "test-requirements.txt"]:
                 if os.path.exists(requirement_file):
                     self._run_command_in_shell(f"{self._activate_venv_cmd()} && "
@@ -221,9 +225,8 @@ class Run:
         os.chdir(self._python_driver_git)
         if self._checkout_branch() and self._apply_patch_files() and self._install_python_requirements():
             prefix = ""
-            if self._python_driver_type == "scylla":
-                prefix = "uv "
-            self._run_command_in_shell(f"{self._activate_venv_cmd()} && {prefix}pip install -e .")
+            if self._python_driver_type != "scylla":
+                self._run_command_in_shell(f"{self._activate_venv_cmd()} && {prefix}pip install -e .")
             debug = '--log-cli-level=debug' if os.environ.get("DEV_MODE") else ''
             if self._python_driver_type == "scylla":
                 prefix = "uv run "


### PR DESCRIPTION
## Summary
- use `uv sync --active --group dev --inexact` for Scylla driver checkouts
- keep the existing requirements-file installation path for non-Scylla driver checkouts
- skip the duplicate editable install after `uv sync`, because sync already installs the project

## Why
`scylladb/python-driver#609` is real for the matrix runner: modern Scylla driver tags no longer have `requirements.txt` / `test-requirements.txt`, but the runner still installed only `uv pip install -e .`. That misses the `dev` dependency group used by the driver tests.

## Verification
- `python -m py_compile run.py`
- temp clone of `scylladb/python-driver`: `uv sync --active --group dev --inexact`
- verified `from cassandra.column_encryption.policies import AES256ColumnEncryptionPolicy` succeeds in that synced environment

Fixes #136
