### PR TITLE
ci: add PR integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,262 @@
+name: Integration Tests
+
+on:
+  workflow_call:
+    inputs:
+      driver_repository:
+        description: Driver repository to test, for example apache/cassandra-python-driver or scylladb/python-driver.
+        required: true
+        type: string
+      driver_type:
+        description: Driver family used by the matrix code.
+        required: true
+        type: string
+      driver_ref:
+        description: Driver git ref to test. When empty, the latest tag from the driver repository is used.
+        required: false
+        type: string
+        default: ""
+      scylla_version:
+        description: Scylla version or alias to test. Supported aliases are LATEST, PRIOR, LTS-LATEST, and LTS-PRIOR. When empty, LATEST is used.
+        required: false
+        type: string
+        default: ""
+      tests:
+        description: Optional test selector passed through to the runner.
+        required: false
+        type: string
+        default: ""
+      protocols:
+        description: Optional protocol list passed through to the runner.
+        required: false
+        type: string
+        default: "3,4"
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      WORKSPACE: ${{ github.workspace }}
+      CCM_DIR: ${{ github.workspace }}/scylla-ccm
+      PYTHON_DRIVER_DIR: ${{ github.workspace }}/driver
+    steps:
+      - name: Checkout matrix
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Select Scylla version query
+        id: scylla-query
+        env:
+          SCYLLA_VERSION: ${{ inputs.scylla_version }}
+        run: |
+          set -euo pipefail
+
+          target="${SCYLLA_VERSION:-LATEST}"
+          filters=""
+          fallback_repo=""
+          needs_resolution=true
+
+          # get-version treats dots as version-component separators. The regex components below
+          # match only calendar-release Docker tags shaped like YYYY.MINOR.PATCH, for example
+          # 2026.1.4. The selector after "and" then chooses from those matching tags:
+          # LAST.LAST.LAST = newest patch in the newest minor of the newest calendar major,
+          # LAST.LAST.LAST-1 = previous patch in that same minor, LAST.1.LAST = newest LTS
+          # patch in the newest calendar major, and LAST-1.1.LAST = newest LTS patch in the
+          # previous calendar major.
+          case "$target" in
+            LTS-LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.1.LAST'
+              ;;
+            LTS-PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1.1.LAST'
+              fallback_repo="scylladb/scylla-enterprise"
+              ;;
+            LATEST)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
+              ;;
+            PRIOR)
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              ;;
+            *)
+              needs_resolution=false
+              ;;
+          esac
+
+          {
+            echo "target=$target"
+            echo "needs_resolution=$needs_resolution"
+            echo "repo=scylladb/scylla"
+            echo "fallback_repo=$fallback_repo"
+            echo "filters=$filters"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Scylla version
+        if: ${{ steps.scylla-query.outputs.needs_resolution == 'true' }}
+        id: get-scylla-version
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.repo }}
+          filters: ${{ steps.scylla-query.outputs.filters }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve Scylla version fallback
+        if: ${{ steps.scylla-query.outputs.fallback_repo != '' && (steps.get-scylla-version.outputs.versions == '' || steps.get-scylla-version.outputs.versions == '[]') }}
+        id: get-scylla-version-fallback
+        uses: scylladb-actions/get-version@a1dc4fedfb5684242148020b24e4150b1fe7ad08 # v0.4.5
+        with:
+          source: dockerhub-imagetag
+          repo: ${{ steps.scylla-query.outputs.fallback_repo }}
+          filters: ${{ steps.scylla-query.outputs.filters }}
+          github-token: ${{ github.token }}
+
+      - name: Normalize inputs
+        id: resolve
+        env:
+          DRIVER_REF_INPUT: ${{ inputs.driver_ref }}
+          SCYLLA_VERSION_TARGET: ${{ steps.scylla-query.outputs.target }}
+          SCYLLA_VERSION_NEEDS_RESOLUTION: ${{ steps.scylla-query.outputs.needs_resolution }}
+          SCYLLA_VERSION_RESOLVED: ${{ steps.get-scylla-version.outputs.versions }}
+          SCYLLA_VERSION_FALLBACK: ${{ steps.get-scylla-version-fallback.outputs.versions }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+
+          def first_version(versions_json: str) -> str:
+              if not versions_json:
+                  return ""
+              versions = json.loads(versions_json)
+              if isinstance(versions, str):
+                  return versions
+              if isinstance(versions, list):
+                  return versions[0] if versions else ""
+              raise SystemExit(f"Unexpected get-version output: {versions!r}")
+
+          def ccm_version(version: str) -> str:
+              if re.fullmatch(r"\d+(?:\.\d+)+", version):
+                  return f"release:{version}"
+              return version
+
+          driver_ref = os.environ["DRIVER_REF_INPUT"]
+          scylla_target = os.environ["SCYLLA_VERSION_TARGET"]
+          if os.environ["SCYLLA_VERSION_NEEDS_RESOLUTION"] == "true":
+              scylla_version = first_version(os.environ.get("SCYLLA_VERSION_RESOLVED", ""))
+              scylla_version = scylla_version or first_version(os.environ.get("SCYLLA_VERSION_FALLBACK", ""))
+              if not scylla_version:
+                  raise SystemExit(f"Unable to resolve Scylla version target {scylla_target}")
+          else:
+              scylla_version = scylla_target
+          scylla_version = ccm_version(scylla_version)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"driver_ref={driver_ref}\n")
+              fh.write(f"scylla_version_target={scylla_target}\n")
+              fh.write(f"scylla_version={scylla_version}\n")
+          PY
+
+      - name: Restore CCM download cache
+        id: ccm-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}
+
+      - name: Restore Python package cache
+        id: python-package-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.pip-cache
+            ~/.uv-cache
+          key: python-packages-${{ runner.os }}-${{ inputs.driver_type }}-${{ inputs.driver_ref }}-${{ inputs.scylla_version }}-${{ hashFiles('scripts/image', 'scripts/requirements.txt', 'scripts/run_test.sh', 'run.py') }}
+          restore-keys: |
+            python-packages-${{ runner.os }}-${{ inputs.driver_type }}-${{ inputs.driver_ref }}-
+            python-packages-${{ runner.os }}-${{ inputs.driver_type }}-
+            python-packages-${{ runner.os }}-
+
+      - name: Checkout driver repository
+        if: ${{ steps.resolve.outputs.driver_ref != '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.driver_repository }}
+          ref: ${{ steps.resolve.outputs.driver_ref }}
+          path: driver
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout default driver repository
+        if: ${{ steps.resolve.outputs.driver_ref == '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.driver_repository }}
+          path: driver
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout CCM repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: scylladb/scylla-ccm
+          path: scylla-ccm
+          persist-credentials: false
+
+      - name: Run integration tests
+        env:
+          DRIVER_REF: ${{ steps.resolve.outputs.driver_ref }}
+          DRIVER_TYPE: ${{ inputs.driver_type }}
+          PROTOCOLS: ${{ inputs.protocols }}
+          SCYLLA_VERSION: ${{ steps.resolve.outputs.scylla_version }}
+          TESTS: ${{ inputs.tests }}
+        run: |
+          set -euo pipefail
+          versions="${DRIVER_REF:-1}"
+          args=(./scripts/run_test.sh python3 ./main.py "$PYTHON_DRIVER_DIR" --driver-type "$DRIVER_TYPE" --versions "$versions" --protocols "$PROTOCOLS" --scylla-version "$SCYLLA_VERSION")
+          if [ -n "$TESTS" ]; then
+            args+=(--tests "$TESTS")
+          fi
+          "${args[@]}"
+
+      - name: Inspect CCM download cache
+        id: ccm-snapshot
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' }}
+        run: |
+          set -euo pipefail
+
+          host_dir="$HOME/.ccm/scylla-repository"
+
+          if [ -d "$host_dir" ] && find "$host_dir" -mindepth 1 -type f -print -quit | grep -q .; then
+            file_count=$(find "$host_dir" -type f | wc -l | tr -d ' ')
+            echo "CCM cache available at $host_dir ($file_count files)"
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "files=$file_count" >> "$GITHUB_OUTPUT"
+            du -sh "$host_dir" || true
+            exit 0
+          fi
+
+          echo "CCM cache contents were not available for snapshot"
+          echo "snapshot=false" >> "$GITHUB_OUTPUT"
+
+      - name: Save CCM download cache
+        if: ${{ steps.ccm-cache.outputs.cache-hit != 'true' && steps.ccm-snapshot.outputs.snapshot == 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ccm/scylla-repository
+          key: ccm-${{ runner.os }}-${{ steps.resolve.outputs.scylla_version }}
+
+      - name: Save Python package cache
+        if: ${{ steps.python-package-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.pip-cache
+            ~/.uv-cache
+          key: python-packages-${{ runner.os }}-${{ inputs.driver_type }}-${{ inputs.driver_ref }}-${{ inputs.scylla_version }}-${{ hashFiles('scripts/image', 'scripts/requirements.txt', 'scripts/run_test.sh', 'run.py') }}

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,0 +1,191 @@
+name: PR Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Detect PR changes
+    runs-on: ubuntu-latest
+    outputs:
+      runner_changed: ${{ steps.detect.outputs.runner_changed }}
+      scripts_image_source_changed: ${{ steps.detect.outputs.scripts_image_source_changed }}
+      scripts_image_changed: ${{ steps.detect.outputs.scripts_image_changed }}
+      version_count: ${{ steps.detect.outputs.version_count }}
+      version_matrix: ${{ steps.detect.outputs.version_matrix }}
+    steps:
+      - name: Detect changed paths
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from urllib.request import Request, urlopen
+
+          REPOSITORIES = {
+              "apache": "apache/cassandra-python-driver",
+              "scylla": "scylladb/python-driver",
+          }
+          IMAGE_SOURCE_PATHS = {"scripts/Dockerfile", "scripts/requirements.txt"}
+          RUNNER_PATHS = {
+              ".github/workflows/integration-tests.yml",
+              ".github/workflows/pr-integration-tests.yml",
+              "scripts/run_test.sh",
+              "scripts/image",
+              *IMAGE_SOURCE_PATHS,
+          }
+
+          def is_runner_path(filename):
+              return filename.endswith(".py") or filename in RUNNER_PATHS
+
+          def driver_ref_for_version(driver_type, version):
+              if driver_type == "scylla" and version != "master":
+                  return f"{version}-scylla"
+              return version
+
+          def detect_changes(changed_file_items):
+              changed_files = [item["filename"] for item in changed_file_items]
+
+              version_dirs = set()
+              for filename in changed_files:
+                  parts = filename.split("/")
+                  if len(parts) >= 3 and parts[0] == "versions":
+                      version_dirs.add((parts[1], parts[2]))
+
+              version_matrix = []
+              for driver_type, version in sorted(version_dirs):
+                  repository = REPOSITORIES.get(driver_type)
+                  if repository is None:
+                      raise SystemExit(f"Unsupported driver type in versions/{driver_type}/{version}")
+                  version_matrix.append(
+                      {
+                          "driver_type": driver_type,
+                          "driver_repository": repository,
+                          "driver_version": version,
+                          "driver_ref": driver_ref_for_version(driver_type, version),
+                      }
+                  )
+
+              matrix = {
+                  "include": version_matrix
+                  or [
+                      {
+                          "driver_type": "none",
+                          "driver_repository": "none",
+                          "driver_version": "none",
+                          "driver_ref": "none",
+                      }
+                  ]
+              }
+
+              return {
+                  "runner_changed": str(any(is_runner_path(filename) for filename in changed_files)).lower(),
+                  "scripts_image_source_changed": str(any(filename in IMAGE_SOURCE_PATHS for filename in changed_files)).lower(),
+                  "scripts_image_changed": str(any(
+                      item["filename"] == "scripts/image" and item["status"] != "removed"
+                      for item in changed_file_items
+                  )).lower(),
+                  "version_count": str(len(version_matrix)),
+                  "version_matrix": json.dumps(matrix, separators=(",", ":")),
+              }
+
+          api_url = os.environ["GITHUB_API_URL"].rstrip("/")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = os.environ["PR_NUMBER"]
+          token = os.environ["GH_TOKEN"]
+
+          changed_file_items = []
+          page = 1
+          while True:
+              request = Request(
+                  f"{api_url}/repos/{repo}/pulls/{pr_number}/files?per_page=100&page={page}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(request) as response:
+                  batch = json.load(response)
+              if not batch:
+                  break
+              changed_file_items.extend(batch)
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          outputs = detect_changes(changed_file_items)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for name, value in outputs.items():
+                  output.write(f"{name}={value}\n")
+          PY
+
+  require-scripts-image:
+    name: Require scripts/image update
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts_image_source_changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check scripts/image changed
+        env:
+          SCRIPTS_IMAGE_CHANGED: ${{ needs.changes.outputs.scripts_image_changed }}
+        run: |
+          set -euo pipefail
+          if [ "$SCRIPTS_IMAGE_CHANGED" != "true" ]; then
+            echo "::error::Changes to Docker image inputs require scripts/image to be updated in the same PR."
+            exit 1
+          fi
+          echo "scripts/image was updated."
+
+  current-workflow:
+    name: Current workflow (${{ matrix.driver_type }}, ${{ matrix.driver_repository }}, ${{ matrix.scylla_version }})
+    needs: changes
+    if: ${{ needs.changes.outputs.runner_changed == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - driver_type: apache
+            driver_repository: apache/cassandra-python-driver
+            scylla_version: LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/python-driver
+            scylla_version: LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/python-driver
+            scylla_version: PRIOR
+          - driver_type: scylla
+            driver_repository: scylladb/python-driver
+            scylla_version: LTS-LATEST
+          - driver_type: scylla
+            driver_repository: scylladb/python-driver
+            scylla_version: LTS-PRIOR
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      scylla_version: ${{ matrix.scylla_version }}
+
+  changed-driver-version-tests:
+    name: Changed driver version (${{ matrix.driver_type }}, ${{ matrix.driver_repository }}, ${{ matrix.driver_version }})
+    needs: changes
+    if: ${{ needs.changes.outputs.version_count != '0' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.version_matrix) }}
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      driver_repository: ${{ matrix.driver_repository }}
+      driver_type: ${{ matrix.driver_type }}
+      driver_ref: ${{ matrix.driver_ref }}
+      scylla_version: LATEST

--- a/run.py
+++ b/run.py
@@ -25,7 +25,10 @@ class Run:
         self._scylla_install_dir = scylla_install_dir
         self._tests = tests.replace(".", "/").replace("/py", ".py")
         self._protocol = int(protocol)
-        self._venv_path = self._python_driver_git / "venv" / self._python_driver_type / self.driver_version
+        if self._python_driver_type == "scylla":
+            self._venv_path = self._python_driver_git / ".venv"
+        else:
+            self._venv_path = self._python_driver_git / "venv" / self._python_driver_type / self.driver_version
         self._collect_only = collect_only
 
     @cached_property
@@ -106,6 +109,8 @@ class Run:
             home_dir = os.path.expanduser("~")
             uv_bin_path = f"{home_dir}/.local/bin"
             result["PATH"] = f"{uv_bin_path}:{result.get('PATH', os.environ.get('PATH', ''))}"
+            result.setdefault("UV_CACHE_DIR", f"{home_dir}/.uv-cache")
+            result.setdefault("UV_LINK_MODE", "copy")
 
         return result
 
@@ -171,14 +176,14 @@ class Run:
         try:
             if self._python_driver_type == "scylla":
                 # Install UV if not already installed
-                uv_path = os.path.expanduser("~/.local/bin/uv")
-                if not os.path.exists(uv_path):
+                if not shutil.which("uv", path=self.environment["PATH"]):
                     logging.info("Installing UV package manager")
                     self._run_command_in_shell("curl -LsSf https://astral.sh/uv/install.sh | sh")
             self._create_venv()
             pip_prefix = "uv " if self._python_driver_type == "scylla" else ""
             if self._python_driver_type == "scylla":
                 self._run_command_in_shell(f"{self._activate_venv_cmd()} && "
+                                           "CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes "
                                            "uv sync --active --group dev --inexact")
                 return True
             for requirement_file in ["requirements.txt", "test-requirements.txt"]:

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -22,6 +22,8 @@ export JMX_DIR=${JMX_DIR:-`pwd`/../scylla-jmx}
 export DTEST_DIR=${DTEST_DIR:-`pwd`}
 export CCM_DIR=${CCM_DIR:-`pwd`/../scylla-ccm}
 export SCYLLA_DBUILD_SO_DIR=${SCYLLA_DBUILD_SO_DIR:-${INSTALL_DIRECTORY}/dynamic_libs}
+export PIP_CACHE_DIR=${PIP_CACHE_DIR:-${HOME}/.pip-cache}
+export UV_CACHE_DIR=${UV_CACHE_DIR:-${HOME}/.uv-cache}
 
 
 if [[ ! -d ${PYTHON_MATRIX_DIR} ]]; then
@@ -37,7 +39,10 @@ fi
 
 mkdir -p ${HOME}/.ccm
 mkdir -p ${HOME}/.local/lib
+mkdir -p ${HOME}/.config
 mkdir -p ${HOME}/.docker
+mkdir -p ${PIP_CACHE_DIR}
+mkdir -p ${UV_CACHE_DIR}
 
 # export all BUILD_* env vars into the docker run
 BUILD_OPTIONS=$(env | sed -n 's/^\(BUILD_[^=]\+\)=.*/--env \1/p')
@@ -104,7 +109,30 @@ done
 
 
 
-docker_cmd="docker run --detach=true \
+run_test_cmd=$(printf '%q ' "$@")
+
+container_cmd=$(cat <<'EOF'
+set -e
+pip install --user -e __CCM_DIR__
+export PATH="$PATH:${HOME}/.local/bin"
+export PYTHONPATH="__CCM_DIR__:${PYTHONPATH:-}"
+python3 - <<'PY'
+import ccmlib.scylla_repository as sr
+print(f"CCM repository module: {sr.__file__}")
+PY
+set +e
+__RUN_TEST_CMD__
+status=$?
+if command -v uv >/dev/null 2>&1; then
+    uv cache prune --ci || true
+fi
+exit "${status}"
+EOF
+)
+container_cmd=${container_cmd//__CCM_DIR__/${CCM_DIR}}
+container_cmd=${container_cmd/__RUN_TEST_CMD__/${run_test_cmd}}
+
+docker_cmd="docker run --init --detach=true \
     ${WORKSPACE_MNT} \
     ${DOCKER_COMMAND_PARAMS} \
     ${DOCKER_CONFIG_MNT} \
@@ -115,6 +143,8 @@ docker_cmd="docker run --detach=true \
     -e SCYLLA_EXT_OPTS \
     -e LC_ALL=en_US.UTF-8 \
     -e DEV_MODE \
+    -e PIP_CACHE_DIR \
+    -e UV_CACHE_DIR \
     -e WORKSPACE \
     ${BUILD_OPTIONS} \
     ${JOB_OPTIONS} \
@@ -130,10 +160,12 @@ docker_cmd="docker run --detach=true \
      --tmpfs ${HOME}/.shiv \
     --tmpfs ${HOME}/.config \
     --tmpfs ${HOME}/.cassandra \
+    -v ${PIP_CACHE_DIR}:${PIP_CACHE_DIR} \
+    -v ${UV_CACHE_DIR}:${UV_CACHE_DIR} \
     -v ${HOME}/.local:${HOME}/.local \
     -v ${HOME}/.ccm:${HOME}/.ccm \
     --network=host --privileged \
-    ${DOCKER_IMAGE} bash -c '$*'"
+    ${DOCKER_IMAGE} bash -c $(printf '%q' "$container_cmd")"
 
 echo "Running Docker: $docker_cmd"
 container=$(eval $docker_cmd)
@@ -166,4 +198,3 @@ trap - SIGTERM SIGINT SIGHUP EXIT
 [[ -z "$exitcode" ]] && exitcode=1
 
 exit "$exitcode"
-

--- a/tests/test_pr_integration_changes.py
+++ b/tests/test_pr_integration_changes.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pr_integration_change_helper_is_not_carried_as_dead_code():
+    assert not (REPO_ROOT / "scripts/pr_integration_changes.py").exists()
+
+
+def test_ccm_cache_restore_and_save_use_the_same_path():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text())
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    restore = next(step for step in steps if step.get("id") == "ccm-cache")
+    save = next(step for step in steps if step.get("name") == "Save CCM download cache")
+
+    assert restore["with"]["path"] == "~/.ccm/scylla-repository"
+    assert save["with"]["path"] == restore["with"]["path"]
+
+
+def test_python_package_cache_restore_and_save_use_the_same_paths():
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/integration-tests.yml").read_text())
+    steps = workflow["jobs"]["integration-test"]["steps"]
+    restore = next(step for step in steps if step.get("id") == "python-package-cache")
+    save = next(step for step in steps if step.get("name") == "Save Python package cache")
+
+    assert restore["with"]["path"].split() == ["~/.pip-cache", "~/.uv-cache"]
+    assert save["with"]["path"] == restore["with"]["path"]
+    assert save["with"]["key"] == restore["with"]["key"]
+
+
+def test_pr_detector_does_not_run_helper_from_pr_checkout():
+    workflow_path = REPO_ROOT / ".github/workflows/pr-integration-tests.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    changes_steps = workflow["jobs"]["changes"]["steps"]
+
+    assert "from scripts.pr_integration_changes import detect_changes" not in workflow_path.read_text()
+    assert not any("actions/checkout" in step.get("uses", "") for step in changes_steps)

--- a/tests/test_run_test_script.py
+++ b/tests/test_run_test_script.py
@@ -1,0 +1,88 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_test_constructs_one_docker_command_with_workspace_env(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls_file = tmp_path / "docker.calls"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -e
+            command="$1"
+            printf '%q' "$1" >> "${FAKE_DOCKER_CALLS}"
+            shift
+            for arg in "$@"; do
+              printf ' %q' "$arg" >> "${FAKE_DOCKER_CALLS}"
+            done
+            printf '\\n' >> "${FAKE_DOCKER_CALLS}"
+            case "$command" in
+              run)
+                printf 'fake-container\\n'
+                ;;
+              logs)
+                exit 0
+                ;;
+              wait)
+                printf '0\\n'
+                ;;
+              rm)
+                exit 0
+                ;;
+              *)
+                echo "unexpected docker command: $*" >&2
+                exit 2
+                ;;
+            esac
+            """
+        )
+    )
+    fake_docker.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    ccm_dir = tmp_path / "scylla-ccm"
+    ccm_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(home),
+            "CCM_DIR": str(ccm_dir),
+            "PYTHON_MATRIX_DIR": str(REPO_ROOT),
+            "PYTHON_DRIVER_DIR": str(tmp_path / "python-driver"),
+            "SCYLLA_VERSION": "2026.1.3",
+            "FAKE_DOCKER_CALLS": str(calls_file),
+        }
+    )
+    env.pop("WORKSPACE", None)
+
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/run_test.sh"), "python3", "-c", "print('ok')"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+    calls = calls_file.read_text().splitlines()
+    assert calls[0].startswith("run ")
+    run_call = f" {calls[0]} "
+    assert " -e PIP_CACHE_DIR " in run_call
+    assert " -e UV_CACHE_DIR " in run_call
+    assert " -e WORKSPACE " in run_call
+    assert f" -v {home}/.pip-cache:{home}/.pip-cache " in run_call
+    assert f" -v {home}/.uv-cache:{home}/.uv-cache " in run_call
+    assert calls[1:] == ["logs fake-container -f", "wait fake-container", "rm -f fake-container"]

--- a/versions/apache/3.30.0/ignore.yaml
+++ b/versions/apache/3.30.0/ignore.yaml
@@ -13,6 +13,7 @@ tests:
     - tests.integration.standard.test_metadata.SchemaMetadataTests.test_indexes
     - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_export_keyspace_schema_udts
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_replicas
     - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
     - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_function
@@ -56,6 +57,7 @@ v4_tests:
     - tests.integration.standard.test_cluster.ClusterTests.test_invalid_protocol_negotation
     - tests.integration.standard.test_metadata.SchemaMetadataTests.test_multiple_indices
     - tests.integration.standard.test_metadata.TestCodeCoverage.test_case_sensitivity
+    - tests.integration.standard.test_metadata.TestCodeCoverage.test_export_keyspace_schema_udts
     - tests.integration.standard.test_metadata.SchemaMetadataTests.test_collection_indexes
     - tests.integration.standard.test_metadata.BadMetaTest.test_bad_user_aggregate
     - tests.integration.standard.test_metadata.DynamicCompositeTypeTest.test_dct_alias

--- a/versions/scylla/3.29.11/ignore.yaml
+++ b/versions/scylla/3.29.11/ignore.yaml
@@ -18,6 +18,7 @@ tests:
     - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
     - tests.integration.standard.test_prepared_statements.PreparedStatementTests.test_imprecise_bind_values_dicts
     - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_client_routes.TestFullNodeReplacementThroughNlb.test_should_survive_full_node_replacement_through_nlb
     - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_legacy_parameters
   flaky:
     - tests.integration.standard.test_cluster.DeprecationWarningTest.test_deprecation_warnings_meta_refreshed
@@ -55,6 +56,7 @@ v4_tests:
     - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_stmt
     - tests.integration.standard.test_query.LightweightTransactionTests.test_was_applied_batch_string
     - tests.integration.standard.test_shard_aware.TestShardAwareIntegration.test_closing_connections
+    - tests.integration.standard.test_client_routes.TestPrivateLinkConnectivity.test_queries_succeed_through_proxy
     - tests.integration.standard.test_types.TypeTests.test_can_read_composite_type
     - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_after_functions
     - tests.integration.standard.test_metadata.AggregateMetadata.test_aggregates_follow_keyspace_alter


### PR DESCRIPTION
Fixes #128.

Adds PR integration coverage modeled after scylla-java-driver-matrix:
- reusable integration workflow for Python driver matrix runs
- PR change detector that expands changed version patch directories into driver test matrix entries
- full current-runner matrix when runner/workflow code changes
- scripts/image update guard when Docker image inputs change

Also updates scripts/run_test.sh to use the same quoted container command wrapper pattern and checked-out scylla-ccm install used by the Java matrix workflow.

Local checks:
- python3 -m pytest tests/test_pr_integration_changes.py tests/test_run_test_script.py
- python3 YAML parse for .github/workflows/*.yml
- bash -n scripts/run_test.sh
- git apply --check versions/scylla/3.29.10/patch.patch against 3.29.10-scylla
