### PR TITLE
Fix Scylla driver matrix failures for tags without a dev dependency group

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,9 +66,10 @@ jobs:
           # match only calendar-release Docker tags shaped like YYYY.MINOR.PATCH, for example
           # 2026.1.4. The selector after "and" then chooses from those matching tags:
           # LAST.LAST.LAST = newest patch in the newest minor of the newest calendar major,
-          # LAST.LAST.LAST-1 = previous patch in that same minor, LAST.1.LAST = newest LTS
-          # patch in the newest calendar major, and LAST-1.1.LAST = newest LTS patch in the
-          # previous calendar major.
+          # LAST-1 = the second-newest calendar release overall (robust global position filter
+          # that still resolves when the newest minor only has a single patch release),
+          # LAST.1.LAST = newest LTS patch in the newest calendar major, and LAST-1.1.LAST =
+          # newest LTS patch in the previous calendar major.
           case "$target" in
             LTS-LATEST)
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.1.LAST'
@@ -81,7 +82,7 @@ jobs:
               filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST'
               ;;
             PRIOR)
-              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST-1'
+              filters='^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST-1'
               ;;
             *)
               needs_resolution=false

--- a/run.py
+++ b/run.py
@@ -169,6 +169,20 @@ class Run:
     def _activate_venv_cmd(self):
         return f"source {self._venv_path}/bin/activate"
 
+    def _has_dev_dependency_group(self) -> bool:
+        pyproject = self._python_driver_git / "pyproject.toml"
+        if not pyproject.exists():
+            return False
+        in_dependency_groups = False
+        for line in pyproject.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                in_dependency_groups = stripped == "[dependency-groups]"
+                continue
+            if in_dependency_groups and re.match(r"^dev\s*=", stripped):
+                return True
+        return False
+
     @lru_cache(maxsize=None)
     def _install_python_requirements(self):
         if os.environ.get("DEV_MODE", False) and self._venv_path.exists() and self._venv_path.is_dir():
@@ -182,9 +196,12 @@ class Run:
             self._create_venv()
             pip_prefix = "uv " if self._python_driver_type == "scylla" else ""
             if self._python_driver_type == "scylla":
+                # Older driver tags don't define a "dev" dependency group, so only
+                # request it when it actually exists to avoid "Group `dev` is not defined".
+                group_arg = "--group dev " if self._has_dev_dependency_group() else ""
                 self._run_command_in_shell(f"{self._activate_venv_cmd()} && "
                                            "CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes "
-                                           "uv sync --active --group dev --inexact")
+                                           f"uv sync --active {group_arg}--inexact")
                 return True
             for requirement_file in ["requirements.txt", "test-requirements.txt"]:
                 if os.path.exists(requirement_file):

--- a/run.py
+++ b/run.py
@@ -183,6 +183,12 @@ class Run:
                 return True
         return False
 
+    def _uses_uv_sync(self) -> bool:
+        # Newer Scylla driver tags declare their test/dev dependencies in a "dev"
+        # dependency group and are installed via "uv sync". Older tags keep them in
+        # requirements.txt/test-requirements.txt and must use the pip fallback.
+        return self._python_driver_type == "scylla" and self._has_dev_dependency_group()
+
     @lru_cache(maxsize=None)
     def _install_python_requirements(self):
         if os.environ.get("DEV_MODE", False) and self._venv_path.exists() and self._venv_path.is_dir():
@@ -195,13 +201,10 @@ class Run:
                     self._run_command_in_shell("curl -LsSf https://astral.sh/uv/install.sh | sh")
             self._create_venv()
             pip_prefix = "uv " if self._python_driver_type == "scylla" else ""
-            if self._python_driver_type == "scylla":
-                # Older driver tags don't define a "dev" dependency group, so only
-                # request it when it actually exists to avoid "Group `dev` is not defined".
-                group_arg = "--group dev " if self._has_dev_dependency_group() else ""
+            if self._uses_uv_sync():
                 self._run_command_in_shell(f"{self._activate_venv_cmd()} && "
                                            "CASS_DRIVER_BUILD_EXTENSIONS_ARE_MUST=yes "
-                                           f"uv sync --active {group_arg}--inexact")
+                                           "uv sync --active --group dev --inexact")
                 return True
             for requirement_file in ["requirements.txt", "test-requirements.txt"]:
                 if os.path.exists(requirement_file):
@@ -247,8 +250,10 @@ class Run:
         os.chdir(self._python_driver_git)
         if self._checkout_branch() and self._apply_patch_files() and self._install_python_requirements():
             prefix = ""
-            if self._python_driver_type != "scylla":
-                self._run_command_in_shell(f"{self._activate_venv_cmd()} && {prefix}pip install -e .")
+            if not self._uses_uv_sync():
+                # "uv sync" already installs the project; otherwise install it editable.
+                install_prefix = "uv " if self._python_driver_type == "scylla" else ""
+                self._run_command_in_shell(f"{self._activate_venv_cmd()} && {install_prefix}pip install -e .")
             debug = '--log-cli-level=debug' if os.environ.get("DEV_MODE") else ''
             if self._python_driver_type == "scylla":
                 prefix = "uv run "


### PR DESCRIPTION
The driver matrix started failing on Scylla master. Commit 1710b8253c7fd64959c9774f23b31552108c3957 replaced the Scylla install path with an unconditional `uv sync --active --group dev --inexact`.

Older Scylla driver tags (e.g. 3.28.2) don't define a dev group in their [pyproject.toml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and keep their test dependencies in requirements.txt / test-requirements.txt. This caused failures.

This PR checks if `dev` group is defined and falls back to old behavior if not.

Tested in: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/sylwia.szunejko/job/python-driver-matrix-test/40/