### PR TITLE
tests: xfail LWT tests without tablet support

### DIFF
--- a/versions/apache/3.29.3/patch.patch
+++ b/versions/apache/3.29.3/patch.patch
@@ -889,3 +889,27 @@ index ae056d77..574d90ab 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
+diff --git a/tests/integration/standard/test_query.py b/tests/integration/standard/test_query.py
+index 311d64d2..07dcf012 100644
+--- a/tests/integration/standard/test_query.py
++++ b/tests/integration/standard/test_query.py
+@@ -808,1 +808,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update(self):
+@@ -832,1 +835,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_prepared_statements(self):
+@@ -854,1 +860,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_batch_statements(self):
+@@ -917,1 +926,4 @@ class LightweightTransactionTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=AttributeError)
+     def test_no_connection_refused_on_timeout(self):

--- a/versions/apache/3.30.0/patch.patch
+++ b/versions/apache/3.30.0/patch.patch
@@ -802,3 +802,27 @@ index 9c3e560b..5b347ce2 100644
  
              # create the schema
              self.nested_udt_schema_helper(s, max_nesting_depth)
+diff --git a/tests/integration/standard/test_query.py b/tests/integration/standard/test_query.py
+index da512f8f..943c527f 100644
+--- a/tests/integration/standard/test_query.py
++++ b/tests/integration/standard/test_query.py
+@@ -810,1 +810,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update(self):
+@@ -834,1 +837,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_prepared_statements(self):
+@@ -856,1 +862,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_batch_statements(self):
+@@ -919,1 +928,4 @@ class LightweightTransactionTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=AttributeError)
+     def test_no_connection_refused_on_timeout(self):

--- a/versions/scylla/3.28.2/patch.patch
+++ b/versions/scylla/3.28.2/patch.patch
@@ -1176,3 +1176,27 @@ index 56136b6e..662181a3 100644
  
  
  class ConnectionTest(unittest.TestCase):
+diff --git a/tests/integration/standard/test_query.py b/tests/integration/standard/test_query.py
+index 10d74a53..7d34e021 100644
+--- a/tests/integration/standard/test_query.py
++++ b/tests/integration/standard/test_query.py
+@@ -806,1 +806,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update(self):
+@@ -830,1 +833,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_prepared_statements(self):
+@@ -852,1 +858,4 @@ class SerialConsistencyTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=InvalidRequest)
+     def test_conditional_update_with_batch_statements(self):
+@@ -915,1 +924,4 @@ class LightweightTransactionTests(unittest.TestCase):
++    @xfail_scylla_version_lt(reason='scylladb/scylladb#18068 - LWT is not yet supported with tablets',
++                             scylla_version='2025.4',
++                             raises=AttributeError)
+     def test_no_connection_refused_on_timeout(self):


### PR DESCRIPTION
The python-driver matrix job failed on LWT tests because the older driver versions in this matrix do not carry the current driver xfail for Scylla versions where LWT is not supported with tablets.

Jenkins failure checked: https://jenkins.scylladb.com/job/scylla-2025.1/job/driver-tests/job/python-driver-matrix-test/25/

Current `scylladb/python-driver` master already handles this in commit `2b5dd164a` (`tests: xfail LWT tests on Scylla versions without tablet LWT support`). The existing `versions/scylla/3.29.10/patch.patch` also already has the same behavior, which is why that leg passed.

This PR adds the matching `xfail_scylla_version_lt(... scylla_version='2025.4' ...)` decorators to the missing matrix patch files:

- `versions/apache/3.29.3/patch.patch`
- `versions/apache/3.30.0/patch.patch`
- `versions/scylla/3.28.2/patch.patch`

Validation:

- `git diff --check`
- Applied each full patch file from a clean tag checkout and confirmed the decorators land directly above the intended LWT tests:
  - Apache `3.29.3`
  - Apache `3.30.0`
  - Scylla `3.28.2-scylla`
- `python3 -m pytest tests` still has an unrelated existing failure in `tests/test_report.py::TestReportMechanism::test_xpassed`; result: `14 passed, 1 failed`.
